### PR TITLE
Rename repo and prepare package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
-  "name": "dmp-frontend",
-  "version": "0.0.1",
-  "lockfileVersion": 1,
+  "name": "digitalmarketplace-govuk-frontend-repository",
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.5.5",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "dmp-frontend",
-  "version": "0.0.1",
-  "description": "Digital Marketplace Frontend - Containing GOV.UK Frontned (Sass,JavaScrip, nunjucks templates) and Digital Marketplace custom components",
-  "main": "index.js",
+  "private": true,
+  "name": "digitalmarketplace-govuk-frontend-repository",
+  "description": "Used only for the development of Digital Marketplace GOV.UK Frontend, see `package/package.json` for the published `package.json`",
+  "engines": {
+    "node": "10.15.1"
+  },
   "scripts": {
     "test": "npm test",
     "build": "standard && gulp --silent"
   },
-  "author": "",
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.2",
@@ -17,5 +18,11 @@
     "gulp-debug": "^4.0.0",
     "node-emoji": "^1.10.0",
     "standard": "^14.3.1"
+  },
+  "standard": {
+    "ignore": [
+      "/package/**/*",
+      "/node_modules/**/*"
+    ]
   }
 }


### PR DESCRIPTION
- Renames the repo
- Prepares package.json by making this private. We only want to be able to publish the package directory and version that directory