### PR TITLE
Fixes release to branch feature

### DIFF
--- a/bin/release-to-branch.sh
+++ b/bin/release-to-branch.sh
@@ -22,24 +22,19 @@ git checkout -b $BRANCH_NAME
 # Build the package as normal
 npm run build
 
-# Check if the new built package has anything new to commit
-if [[ -n $(git status --porcelain) ]]; then
-  echo "✍️ Commiting changed package"
-  git add package/
+echo "✍️ Commiting changed package"
+git add package/ --force
 
-  git commit -m "Release Digital Marketplace GOV.UK Frontend to '$BRANCH_NAME' for testing"
+git commit -m "Release Digital Marketplace GOV.UK Frontend to '$BRANCH_NAME' for testing"
 
-  # Create a local branch containing the package directory
-  echo "✨ Filter the branch to only the package/ directory..."
-  git filter-branch --force --subdirectory-filter package
+# Create a local branch containing the package directory
+echo "✨ Filter the branch to only the package/ directory..."
+git filter-branch --force --subdirectory-filter package
 
-  # Force the push of the branch to the remote Github origin
-  git push origin $BRANCH_NAME:$BRANCH_NAME --force
+# Force the push of the branch to the remote Github origin
+git push origin $BRANCH_NAME:$BRANCH_NAME --force
 
-  echo "⚠️ Branch pushed to '$BRANCH_NAME', do not edit this by hand."
-else
-  echo "⚠️ No new changes to the package."
-fi
+echo "⚠️ Branch pushed to '$BRANCH_NAME', do not edit this by hand."
 
 git checkout -
 


### PR DESCRIPTION
Unfortunately, we could not completely use GOV.UK Frontend code without
a small modification.

The issue was that GOV.UK Frontend versions everything inside their `package/`
folder. This meant that the release-to-branch.sh was pushing up package/govuk-frontend
to githube. However, in our case we are not interested in versioning our compiled
code because the compiled code is only used when we publish a release.

So to get this to work we force add `package/` just for the new pre-release
branch we use for testing.