### PR TITLE
Add error templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package/govuk-frontend/
+package/digitalmarketplace/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+- Add error templates
+
+  Error templates which use GOV.UK Frontend classes for styling.
+
+  ([PR #14](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/14))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -6,7 +6,7 @@ echo " "
 echo "This will:"
 echo "- run the test suite"
 echo "- build GOV.UK Frontend into the 'package/' directory"
-#echo "- build Digital Marketplace Frontend into the 'package/' directory"
+echo "- build Digital Marketplace Frontend into the 'package/' directory"
 echo "- commit all changes and push the branch to remote"
 echo " "
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,9 @@
-// Clean compiled files/folders
-const { task, series } = require('gulp')
+const { task, series, parallel } = require('gulp')
 require('./tasks/gulp/clean')
 require('./tasks/gulp/build')
 
-task('build', series('clean', 'build:govuk-frontend'))
+task('build',
+  series('clean',
+    parallel('build:govuk-frontend', 'build:digitalmarketplace')
+  )
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2161,11 +2161,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
-      "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA=="
-    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -2334,19 +2329,6 @@
             "yargs": "^7.1.0"
           }
         }
-      }
-    },
-    "gulp-debug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-4.0.0.tgz",
-      "integrity": "sha512-cn/GhMD2nVZCVxAl5vWao4/dcoZ8wUJ8w3oqTvQaGDmC1vT7swNOEbhQTWJp+/otKePT64aENcqAQXDcdj5H1g==",
-      "requires": {
-        "chalk": "^2.3.0",
-        "fancy-log": "^1.3.2",
-        "plur": "^3.0.0",
-        "stringify-object": "^3.0.0",
-        "through2": "^2.0.0",
-        "tildify": "^1.1.2"
       }
     },
     "gulplog": {
@@ -2544,11 +2526,6 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
-    "irregular-plurals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-      "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw=="
-    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -2688,11 +2665,6 @@
         }
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -2723,11 +2695,6 @@
       "requires": {
         "has": "^1.0.1"
       }
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-relative": {
       "version": "1.0.0",
@@ -3320,11 +3287,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -3593,14 +3555,6 @@
             "locate-path": "^2.0.0"
           }
         }
-      }
-    },
-    "plur": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
-      "integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
-      "requires": {
-        "irregular-plurals": "^2.0.0"
       }
     },
     "posix-character-classes": {
@@ -4240,16 +4194,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
-      }
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -4355,14 +4299,6 @@
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
-      }
-    },
-    "tildify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "requires": {
-        "os-homedir": "^1.0.0"
       }
     },
     "time-stamp": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "del": "^5.1.0",
     "govuk-frontend": "^2.13.0",
     "gulp": "^4.0.2",
-    "gulp-debug": "^4.0.0",
     "node-emoji": "^1.10.0",
     "standard": "^14.3.1"
   },

--- a/src/digitalmarketplace/templates/errors/400.html
+++ b/src/digitalmarketplace/templates/errors/400.html
@@ -1,0 +1,17 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}Bad request - Digital Marketplace{% endblock %}
+
+{% block content %}
+  <div class="error-page">
+    <h1 class="govuk-heading-xl">Sorry, there was a problem with your request</h1>
+
+    <p class="govuk-body">
+      {% if error_message %}
+        {{ error_message }}
+      {% else %}
+        Please do not attempt the same request again.
+      {% endif %}
+    </p>
+  </div>
+{% endblock %}

--- a/src/digitalmarketplace/templates/errors/403.html
+++ b/src/digitalmarketplace/templates/errors/403.html
@@ -1,0 +1,25 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}Access denied - 403 – Digital Marketplace{% endblock %}
+
+{% block breadcrumbs %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('main.index')
+      },
+      {
+        "text": "Access denied"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">You don’t have permission to perform this action</h1>
+
+  <p class="govuk-body">
+    Email <a class="govuk-link" href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need to access this content.
+  </p>
+{% endblock %}

--- a/src/digitalmarketplace/templates/errors/404.html
+++ b/src/digitalmarketplace/templates/errors/404.html
@@ -1,0 +1,16 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}Page could not be found - Digital Marketplace{% endblock %}
+
+{% block content %}
+  <div class="error-page">
+    <h1 class="govuk-heading-xl">Page could not be found</h1>
+
+    <p class="govuk-body">
+      Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
+    </p>
+    <p class="govuk-body">
+      If you can’t find what you’re looking for, contact us at <a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
+    </p>
+  </div>
+{% endblock %}

--- a/src/digitalmarketplace/templates/errors/410.html
+++ b/src/digitalmarketplace/templates/errors/410.html
@@ -1,0 +1,16 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}Service no longer available - Digital Marketplace{% endblock %}
+
+{% block content %}
+  <div class="error-page">
+    <h1 class="govuk-heading-xl">Page no longer available</h1>
+
+    <p class="govuk-body">
+      The page you requested is no longer available on the Digital Marketplace.
+    </p>
+    <p class="govuk-body">
+      If you can't find what you're looking for, email <a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
+    </p>
+  </div>
+{% endblock %}

--- a/src/digitalmarketplace/templates/errors/500.html
+++ b/src/digitalmarketplace/templates/errors/500.html
@@ -1,0 +1,17 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}Sorry, we’re experiencing technical difficulties - Digital Marketplace{% endblock %}
+
+{% block content %}
+  <div class="error-page">
+    <h1 class="govuk-heading-xl">Sorry, we’re experiencing technical difficulties</h1>
+
+    <p class="govuk-body">
+      {% if error_message %}
+        {{ error_message }}
+      {% else %}
+        Try again later.
+      {% endif %}
+    </p>
+  </div>
+{% endblock %}

--- a/tasks/gulp/build.js
+++ b/tasks/gulp/build.js
@@ -7,6 +7,11 @@ const log = require('fancy-log')
 task('build:govuk-frontend', async () => {
   log(`${emoji.get('clipboard')}  ${green.bold('- Copying GOV.UK Frontend to package directory')}`)
   src(['node_modules/govuk-frontend/**'])
-    .pipe(debug({ title: 'Copied' }))
     .pipe(dest('package/govuk-frontend'))
+})
+
+task('build:digitalmarketplace', async () => {
+  log(`${emoji.get('clipboard')}  ${green.bold('- Copying Digital Marketplace to package directory')}`)
+  src(['src/digitalmarketplace/**'])
+    .pipe(dest('package/digitalmarketplace'))
 })

--- a/tasks/gulp/build.js
+++ b/tasks/gulp/build.js
@@ -1,5 +1,4 @@
 const { task, src, dest } = require('gulp')
-const debug = require('gulp-debug')
 const emoji = require('node-emoji')
 const { green } = require('chalk')
 const log = require('fancy-log')


### PR DESCRIPTION
Adds error page templates.

These use GOV.UK Frontend but apart from that the content is identical to the existing templates in digitalmarketplace-frontend-toolkit.

Will help to reduce the number of files in this PR.

https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/560

Ticket: https://trello.com/c/pT5lRLOG