### PR TITLE
Adds script to tag repo releases

### DIFF
--- a/scripts/tag_latest_version.sh
+++ b/scripts/tag_latest_version.sh
@@ -9,6 +9,10 @@ version=v$(jq -r ".version" package/package.json)
 changelog="https://github.com/alphagov/digitalmarketplace-govuk-frontend/blob/master/CHANGELOG.md#"
 echo Version:\ \ $version
 echo "================================================================================"
-git tag -a $version -m "Digital Marketplace GOV.UK Frontend release $version" -m "[Changelog]($changelog$version)"
-echo "New tag created!"
+{
+  git tag -a $version -m "Digital Marketplace GOV.UK Frontend release $version" -m "[Changelog]($changelog$version)" && echo "New tag created!"
+} || {
+  echo "Tagging failed, probably because the tag already exists."
+}
+
 echo "--------------------------------------------------------------------------------"

--- a/scripts/tag_latest_version.sh
+++ b/scripts/tag_latest_version.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+echo "≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡"
+echo "TAGGING LATEST VERSION"
+echo "--------------------------------------------------------------------------------"
+git checkout master
+git pull origin master
+version=v$(jq -r ".version" package/package.json)
+changelog="https://github.com/alphagov/digitalmarketplace-govuk-frontend/blob/master/CHANGELOG.md#"
+echo Version:\ \ $version
+echo "================================================================================"
+git tag -a $version -m "Digital Marketplace GOV.UK Frontend release $version" -m "[Changelog]($changelog$version)"
+echo "New tag created!"
+echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
https://trello.com/c/bzsVPMU3/57-jenkins-job-to-auto-tag-digitalmarketplace-govuk-frontend-releases

For use by a (shortly-to-be-created) Jenkins job (similar to the [FE toolkit auto-tag job](https://github.com/alphagov/digitalmarketplace-jenkins/blob/master/job_definitions/toolkit.yml)) which polls for scm changes every 2 minutes. We currently use this system to auto tag our other python and FE toolkit libraries. [See for yourself just how much I've copied this script from the latter.](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/pages_builder/tag_latest_version.sh) 😸

This will remove a step (number 15) from [the manual publishing process](https://github.com/alphagov/digitalmarketplace-govuk-frontend/blob/master/docs/publishing.md). 

The tag version number is taken from the packaged release (`package/package.json`), as the top level package.json does not have a version number. This should be fine in practice as 1) we only care about tagging 'proper releases' 2) the Jenkins polling job can catch/ignore failures if the tag already exists.

The tag message includes a link to the Changelog rather than copying across the full details. This should keep things simple and reduce duplication.

Note for reviewers: my bash is "not the best" so do shout if I've made (or copied across) a massive howler somewhere.