### PR TITLE
New component: Digital Marketplace Footer component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package/govuk-frontend/
 package/digitalmarketplace/
+src/govuk-frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@
 
 - New component: Digital Marketplace Footer component
 
-  ! To use this the application must be using `govuk-frontend` template !
+  *Requirement before using this component:*
+  - To use this the application must be using `govuk-frontend` template
+  - digitalmarketplace-util v48.8.0+ must be installed
 
+  *Installing component:*
   1. Check config.py has this line for jinja to find the components
       ```
                   os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+- New component: Digital Marketplace Footer component
+
+  ! To use this the application must be using `govuk-frontend` template !
+
+  1. Check config.py has this line for jinja to find the components
+      ```
+                  os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend')
+      ```
+
+  2. Import the component in `_base_page.html`
+     `{% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}`
+
+  3. Use the component `{{ dmFooter({}) }}`
+
+  ([PR #21](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/21))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/config/jest-setup.js
+++ b/config/jest-setup.js
@@ -1,0 +1,3 @@
+const { toHaveNoViolations } = require('jest-axe')
+
+expect.extend(toHaveNoViolations)

--- a/config/paths.test.json
+++ b/config/paths.test.json
@@ -1,5 +1,5 @@
 {
-  "dmpSource": "src/digitalmarketplace/",
-  "dmpComponents": "src/digitalmarketplace/components/",
+  "dmSource": "src/digitalmarketplace/",
+  "dmComponents": "src/digitalmarketplace/components/",
   "govukSource": "src/govuk-frontend/"
 }

--- a/config/paths.test.json
+++ b/config/paths.test.json
@@ -1,0 +1,5 @@
+{
+  "dmpSource": "src/digitalmarketplace/",
+  "dmpComponents": "src/digitalmarketplace/components/",
+  "govukSource": "src/govuk-frontend/"
+}

--- a/lib/axe-helper.js
+++ b/lib/axe-helper.js
@@ -1,0 +1,11 @@
+const { configureAxe } = require('jest-axe')
+
+const axe = configureAxe({
+  rules: {
+    // As we're testing incomplete HTML fragments, we don't expect there to be a
+    // skip link.
+    'skip-link': { enabled: false }
+  }
+})
+
+module.exports = axe

--- a/lib/helper-functions.js
+++ b/lib/helper-functions.js
@@ -1,0 +1,21 @@
+'use strict'
+
+// Convert component name to macro name
+//
+// This helper function takes a component name and returns the corresponding
+// macro name.
+//
+// Component names are lowercase, dash-separated strings (button, date-input),
+// whilst macro names have a `govuk` prefix and are camel cased (govukButton,
+// govukDateInput).
+const componentNameToMacroName = componentName => {
+  const macroName = componentName
+    .toLowerCase()
+    .split('-')
+    // capitalize each 'word'
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+
+  return `dm${macroName}`
+}
+exports.componentNameToMacroName = componentNameToMacroName

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -10,7 +10,7 @@ const yaml = require('js-yaml')
 const configPaths = require('../config/paths.test.json')
 const { componentNameToMacroName } = require('./helper-functions.js')
 
-nunjucks.configure([configPaths.govukSource, configPaths.dmComponents], {
+const nunjucksEnv = nunjucks.configure([configPaths.govukSource, configPaths.dmComponents], {
   trimBlocks: true,
   lstripBlocks: true
 })
@@ -19,10 +19,11 @@ nunjucks.configure([configPaths.govukSource, configPaths.dmComponents], {
  * Render a component's macro for testing
  * @param {string} componentName
  * @param {string} params parameters that are used in the component macro
+ * @param {object} macros macros used in the component macro
  * @param {any} children any child components or text, pass the children to the macro
  * @returns {function} returns cheerio (jQuery) instance of the macro for easy DOM querying
  */
-function render (componentName, params, children = false) {
+function render (componentName, params, macros = false, children = false) {
   if (typeof params === 'undefined') {
     throw new Error('Parameters passed to `render` should be an object but are undefined')
   }
@@ -40,7 +41,15 @@ function render (componentName, params, children = false) {
     macroString += `{{- ${macroName}(${macroParams}) -}}`
   }
 
-  const output = nunjucks.renderString(macroString)
+  // For any macros we need to call in the component view for example `url_for`
+  // we add it to nunjucks environment
+  if (macros) {
+    Object.keys(macros).forEach(key => {
+      nunjucksEnv.addGlobal(key, macros[key])
+    })
+  }
+
+  const output = nunjucksEnv.renderString(macroString)
   return cheerio.load(output)
 }
 

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const cheerio = require('cheerio')
+const nunjucks = require('nunjucks')
+const yaml = require('js-yaml')
+
+const configPaths = require('../config/paths.test.json')
+const { componentNameToMacroName } = require('./helper-functions.js')
+
+nunjucks.configure([configPaths.govukSource, configPaths.dmpComponents], {
+  trimBlocks: true,
+  lstripBlocks: true
+})
+
+/**
+ * Render a component's macro for testing
+ * @param {string} componentName
+ * @param {string} params parameters that are used in the component macro
+ * @param {any} children any child components or text, pass the children to the macro
+ * @returns {function} returns cheerio (jQuery) instance of the macro for easy DOM querying
+ */
+function render (componentName, params, children = false) {
+  if (typeof params === 'undefined') {
+    throw new Error('Parameters passed to `render` should be an object but are undefined')
+  }
+
+  const macroName = componentNameToMacroName(componentName)
+  const macroParams = JSON.stringify(params, null, 2)
+
+  let macroString = `{%- from "${componentName}/macro.njk" import ${macroName} -%}`
+
+  // If we're nesting child components or text, pass the children to the macro
+  // using the 'caller' Nunjucks feature
+  if (children) {
+    macroString += `{%- call ${macroName}(${macroParams}) -%}${children}{%- endcall -%}`
+  } else {
+    macroString += `{{- ${macroName}(${macroParams}) -}}`
+  }
+
+  const output = nunjucks.renderString(macroString)
+  return cheerio.load(output)
+}
+
+/**
+ * Get examples from a component's metadata file
+ * @param {string} componentName
+ * @returns {object} returns object that includes all examples at once
+ */
+function getExamples (componentName) {
+  const file = fs.readFileSync(
+    path.join(configPaths.dmpComponents, componentName, `${componentName}.yaml`),
+    'utf8'
+  )
+
+  const docs = yaml.safeLoad(file)
+
+  const examples = {}
+
+  for (const example of docs.examples) {
+    examples[example.name] = example.data
+  }
+
+  return examples
+}
+
+module.exports = { nunjucks, render, getExamples }

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -10,7 +10,7 @@ const yaml = require('js-yaml')
 const configPaths = require('../config/paths.test.json')
 const { componentNameToMacroName } = require('./helper-functions.js')
 
-nunjucks.configure([configPaths.govukSource, configPaths.dmpComponents], {
+nunjucks.configure([configPaths.govukSource, configPaths.dmComponents], {
   trimBlocks: true,
   lstripBlocks: true
 })
@@ -51,7 +51,7 @@ function render (componentName, params, children = false) {
  */
 function getExamples (componentName) {
   const file = fs.readFileSync(
-    path.join(configPaths.dmpComponents, componentName, `${componentName}.yaml`),
+    path.join(configPaths.dmComponents, componentName, `${componentName}.yaml`),
     'utf8'
   )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,6 +1109,12 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1242,6 +1248,31 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "dev": true,
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
     },
     "chokidar": {
       "version": "2.1.8",
@@ -1478,6 +1509,24 @@
         "which": "^1.2.9"
       }
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
@@ -1702,6 +1751,22 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1709,6 +1774,25 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "duplexify": {
@@ -1753,6 +1837,12 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3457,6 +3547,33 @@
       "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "http-signature": {
@@ -5404,6 +5521,15 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,6 +919,12 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axe-core": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.1.tgz",
+      "integrity": "sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ==",
+      "dev": true
+    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -4355,6 +4361,32 @@
         }
       }
     },
+    "jest-axe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-3.2.0.tgz",
+      "integrity": "sha512-QSQwSwG72/cpmhJU0fBsaUUvu9mb2uAqhccGQVG6JbIV8sK+aIXh8hYl7vxraMF/I6soQod1aqSdD/j7LjpVFQ==",
+      "dev": true,
+      "requires": {
+        "axe-core": "3.3.1",
+        "chalk": "2.4.2",
+        "jest-matcher-utils": "24.8.0",
+        "lodash.merge": "4.6.2"
+      },
+      "dependencies": {
+        "jest-matcher-utils": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+          "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.8.0",
+            "jest-get-type": "^24.8.0",
+            "pretty-format": "^24.8.0"
+          }
+        }
+      }
+    },
     "jest-changed-files": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
@@ -5203,6 +5235,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "cheerio": "^1.0.0-rc.3",
     "jest": "^24.9.0",
+    "jest-axe": "^3.2.0",
     "nunjucks": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "node-emoji": "^1.10.0",
     "standard": "^14.3.1"
   },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "./config/jest-setup.js"
+    ]
+  },
   "standard": {
     "env": [
       "jest"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     ]
   },
   "devDependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "jest": "^24.9.0",
     "nunjucks": "^3.2.0"
   }

--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -8,7 +8,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
             <h2 class=\\"govuk-footer__heading govuk-heading-m\\">Contact</h2>
               <ul class=\\"govuk-footer__list govuk-footer__list--columns-3\\">
                     <li class=\\"govuk-footer__list-item\\">
-                      <a class=\\"govuk-footer__link\\" href=\\"/help\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"http://www.google.com\\">
                         Digital Marketplace help
                       </a>
                     </li>
@@ -38,7 +38,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
                       </a>
                     </li>
                     <li class=\\"govuk-footer__list-item\\">
-                      <a class=\\"govuk-footer__link\\" href=\\"/g-cloud/suppliers\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"http://www.gov.uk\\">
                         G-Cloud supplier A-Z
                       </a>
                     </li>

--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`footer renders a footer component with all our standard links 1`] = `
+"<html><head></head><body><footer class=\\"govuk-footer \\" role=\\"contentinfo\\">
+  <div class=\\"govuk-width-container \\">
+      <div class=\\"govuk-footer__navigation\\">
+          <div class=\\"govuk-footer__section\\">
+            <h2 class=\\"govuk-footer__heading govuk-heading-m\\">Contact</h2>
+              <ul class=\\"govuk-footer__list govuk-footer__list--columns-3\\">
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"/help\\">
+                        Digital Marketplace help
+                      </a>
+                    </li>
+              </ul>
+          </div>
+          <div class=\\"govuk-footer__section\\">
+            <h2 class=\\"govuk-footer__heading govuk-heading-m\\">About the Digital Marketplace</h2>
+              <ul class=\\"govuk-footer__list \\">
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/digital-marketplace-buyers-guide\\">
+                        Services you can buy
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/digital-marketplace-suppliers-guide\\">
+                        Services you can sell
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/government/organisations/crown-commercial-service\\">
+                        About Crown Commercial Services
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/government/organisations/government-digital-service\\">
+                        About Government Digital Services
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"/g-cloud/suppliers\\">
+                        G-Cloud supplier A-Z
+                      </a>
+                    </li>
+              </ul>
+          </div>
+          <div class=\\"govuk-footer__section\\">
+            <h2 class=\\"govuk-footer__heading govuk-heading-m\\">Guidance</h2>
+              <ul class=\\"govuk-footer__list \\">
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/g-cloud-suppliers-guide\\">
+                        Applying to sell on the G-Cloud frameword
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide\\">
+                        Applying to sell on the Digital Outcomes and Specialists framework
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/how-to-sell-your-digital-outcomes-and-specialists-services\\">
+                        Responding to buyer requirements on the Digital Outcomes and Specialists framework
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/g-cloud-buyers-guide\\">
+                        Buying on the G-Cloud framework
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide\\">
+                        Buying on the Digital Outcomes and Specialists framework
+                      </a>
+                    </li>
+                    <li class=\\"govuk-footer__list-item\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace\\">
+                        Buying on the Crown Hosting framework
+                      </a>
+                    </li>
+              </ul>
+          </div>
+      </div>
+      <hr class=\\"govuk-footer__section-break\\">
+    <div class=\\"govuk-footer__meta\\">
+      <div class=\\"govuk-footer__meta-item govuk-footer__meta-item--grow\\">
+          <h2 class=\\"govuk-visually-hidden\\">Support links</h2>
+            <ul class=\\"govuk-footer__inline-list\\">
+                <li class=\\"govuk-footer__inline-list-item\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"/terms-and-conditions\\">
+                    Terms and conditions
+                  </a>
+                </li>
+                <li class=\\"govuk-footer__inline-list-item\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"/cookies\\">
+                    Cookies
+                  </a>
+                </li>
+                <li class=\\"govuk-footer__inline-list-item\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"/privacy-notice\\">
+                    Privacy notice
+                  </a>
+                </li>
+            </ul>
+            <div class=\\"govuk-footer__meta-custom\\">
+              Built by the <a href=\\"https://www.gov.uk/government/organisations/government-digital-service\\" class=\\"govuk-footer__link\\">Government Digital Service</a>
+            </div>
+
+        <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-footer__licence-logo\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 483.2 195.7\\" height=\\"17\\" width=\\"41\\">
+          <path fill=\\"currentColor\\" d=\\"M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145\\"/>
+        </svg>
+        <span class=\\"govuk-footer__licence-description\\">
+          All content is available under the
+          <a class=\\"govuk-footer__link\\" href=\\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\\" rel=\\"license\\">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class=\\"govuk-footer__meta-item\\">
+        <a class=\\"govuk-footer__link govuk-footer__copyright-logo\\" href=\\"https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/\\">&#xA9; Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+</body></html>"
+`;

--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -86,17 +86,17 @@ exports[`footer renders a footer component with all our standard links 1`] = `
           <h2 class=\\"govuk-visually-hidden\\">Support links</h2>
             <ul class=\\"govuk-footer__inline-list\\">
                 <li class=\\"govuk-footer__inline-list-item\\">
-                  <a class=\\"govuk-footer__link\\" href=\\"/terms-and-conditions\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"http://www.yahoo.co.uk\\">
                     Terms and conditions
                   </a>
                 </li>
                 <li class=\\"govuk-footer__inline-list-item\\">
-                  <a class=\\"govuk-footer__link\\" href=\\"/cookies\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"http://www.bbc.co.uk\\">
                     Cookies
                   </a>
                 </li>
                 <li class=\\"govuk-footer__inline-list-item\\">
-                  <a class=\\"govuk-footer__link\\" href=\\"/privacy-notice\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"http://www.amazon.co.uk\\">
                     Privacy notice
                   </a>
                 </li>

--- a/src/digitalmarketplace/components/footer/footer.yaml
+++ b/src/digitalmarketplace/components/footer/footer.yaml
@@ -1,0 +1,5 @@
+params:
+examples:
+  - name: default
+    data:
+      {}

--- a/src/digitalmarketplace/components/footer/macro.njk
+++ b/src/digitalmarketplace/components/footer/macro.njk
@@ -1,0 +1,3 @@
+{% macro dmFooter(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -69,16 +69,16 @@
   meta: {
     items: [
       {
-        href: "/terms-and-conditions",
-        text: "Terms and conditions"
+        href: url_for('external.terms-and-conditions'),
+        text: 'Terms and conditions'
       },
       {
-        href: "/cookies",
-        text: "Cookies"
+        href: url_for('external.cookies'),
+        text: 'Cookies'
       },
       {
-        href: "/privacy-notice",
-        text: "Privacy notice"
+        href: url_for('external.privacy-notice'),
+        text: 'Privacy notice'
       }
     ],
     html: 'Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">Government Digital Service</a>'

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -69,7 +69,7 @@
   meta: {
     items: [
       {
-        href: url_for('external.terms-and-conditions'),
+        href: url_for('external.terms_and_conditions'),
         text: 'Terms and conditions'
       },
       {
@@ -77,7 +77,7 @@
         text: 'Cookies'
       },
       {
-        href: url_for('external.privacy-notice'),
+        href: url_for('external.privacy_notice'),
         text: 'Privacy notice'
       }
     ],

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -1,0 +1,86 @@
+{% from "../../../govuk-frontend/components/footer/macro.njk" import govukFooter -%}
+{{ govukFooter({
+  navigation: [
+    {
+      title: 'Contact',
+      columns: 3,
+      items: [
+        {
+          href: '/help',
+          text: 'Digital Marketplace help'
+        }
+      ]
+    },
+    {
+      title: 'About the Digital Marketplace',
+      items: [
+        {
+          href: 'https://www.gov.uk/guidance/digital-marketplace-buyers-guide',
+          text: 'Services you can buy'
+        },
+        {
+          href: 'https://www.gov.uk/guidance/digital-marketplace-suppliers-guide',
+          text: 'Services you can sell'
+        },
+        {
+          href: 'https://www.gov.uk/government/organisations/crown-commercial-service',
+          text: 'About Crown Commercial Services'
+        },
+        {
+          href: 'https://www.gov.uk/government/organisations/government-digital-service',
+          text: 'About Government Digital Services'
+        },
+        {
+          href: '/g-cloud/suppliers',
+          text: 'G-Cloud supplier A-Z'
+        }
+      ]
+    },
+    {
+      title: 'Guidance',
+      items: [
+        {
+          href: 'https://www.gov.uk/guidance/g-cloud-suppliers-guide',
+          text: 'Applying to sell on the G-Cloud frameword'
+        },
+        {
+          href: 'https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide',
+          text: 'Applying to sell on the Digital Outcomes and Specialists framework'
+        },
+        {
+          href: 'https://www.gov.uk/guidance/how-to-sell-your-digital-outcomes-and-specialists-services',
+          text: 'Responding to buyer requirements on the Digital Outcomes and Specialists framework'
+        },
+        {
+          href: 'https://www.gov.uk/guidance/g-cloud-buyers-guide',
+          text: 'Buying on the G-Cloud framework'
+        },
+        {
+          href: 'https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide',
+          text: 'Buying on the Digital Outcomes and Specialists framework'
+        },
+        {
+          href: 'https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace',
+          text: 'Buying on the Crown Hosting framework'
+        }
+      ]
+    }
+  ],
+  meta: {
+    items: [
+      {
+        href: "/terms-and-conditions",
+        text: "Terms and conditions"
+      },
+      {
+        href: "/cookies",
+        text: "Cookies"
+      },
+      {
+        href: "/privacy-notice",
+        text: "Privacy notice"
+      }
+    ],
+    html: 'Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">Government Digital Service</a>'
+  }
+}) }}

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -6,7 +6,7 @@
       columns: 3,
       items: [
         {
-          href: '/help',
+          href: url_for('external.help'),
           text: 'Digital Marketplace help'
         }
       ]
@@ -31,7 +31,7 @@
           text: 'About Government Digital Services'
         },
         {
-          href: '/g-cloud/suppliers',
+          href: url_for('external.suppliers_list_by_prefix'),
           text: 'G-Cloud supplier A-Z'
         }
       ]

--- a/src/digitalmarketplace/components/footer/template.test.js
+++ b/src/digitalmarketplace/components/footer/template.test.js
@@ -10,7 +10,14 @@ const urlForMock = jest.fn((param) => {
     value = 'http://www.google.com'
   } else if (param === 'external.suppliers_list_by_prefix') {
     value = 'http://www.gov.uk'
+  } else if (param === 'external.cookies') {
+    value = 'http://www.bbc.co.uk'
+  } else if (param === 'external.privacy-notice') {
+    value = 'http://www.amazon.co.uk'
+  } else if (param === 'external.terms-and-conditions') {
+    value = 'http://www.yahoo.co.uk'
   }
+
   return value
 })
 

--- a/src/digitalmarketplace/components/footer/template.test.js
+++ b/src/digitalmarketplace/components/footer/template.test.js
@@ -1,0 +1,10 @@
+const { render, getExamples } = require('../../../../lib/jest-helpers.js')
+
+const examples = getExamples('footer')
+
+describe('footer', () => {
+  it('renders a footer component with all our standard links', () => {
+    const $ = render('footer', examples.default)
+    expect($.html()).toMatchSnapshot()
+  })
+})

--- a/src/digitalmarketplace/components/footer/template.test.js
+++ b/src/digitalmarketplace/components/footer/template.test.js
@@ -4,16 +4,26 @@ const { render, getExamples } = require('../../../../lib/jest-helpers.js')
 
 const examples = getExamples('footer')
 
+const urlForMock = jest.fn((param) => {
+  let value = ''
+  if (param === 'external.help') {
+    value = 'http://www.google.com'
+  } else if (param === 'external.suppliers_list_by_prefix') {
+    value = 'http://www.gov.uk'
+  }
+  return value
+})
+
 describe('footer', () => {
   it('default example passes accessibility tests', async () => {
-    const $ = render('footer', examples.default)
+    const $ = render('footer', examples.default, { url_for: urlForMock })
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('renders a footer component with all our standard links', () => {
-    const $ = render('footer', examples.default)
+    const $ = render('footer', examples.default, { url_for: urlForMock })
     expect($.html()).toMatchSnapshot()
   })
 })

--- a/src/digitalmarketplace/components/footer/template.test.js
+++ b/src/digitalmarketplace/components/footer/template.test.js
@@ -1,8 +1,17 @@
+const axe = require('../../../../lib/axe-helper')
+
 const { render, getExamples } = require('../../../../lib/jest-helpers.js')
 
 const examples = getExamples('footer')
 
 describe('footer', () => {
+  it('default example passes accessibility tests', async () => {
+    const $ = render('footer', examples.default)
+
+    const results = await axe($.html())
+    expect(results).toHaveNoViolations()
+  })
+
   it('renders a footer component with all our standard links', () => {
     const $ = render('footer', examples.default)
     expect($.html()).toMatchSnapshot()

--- a/src/digitalmarketplace/components/footer/template.test.js
+++ b/src/digitalmarketplace/components/footer/template.test.js
@@ -12,9 +12,9 @@ const urlForMock = jest.fn((param) => {
     value = 'http://www.gov.uk'
   } else if (param === 'external.cookies') {
     value = 'http://www.bbc.co.uk'
-  } else if (param === 'external.privacy-notice') {
+  } else if (param === 'external.privacy_notice') {
     value = 'http://www.amazon.co.uk'
-  } else if (param === 'external.terms-and-conditions') {
+  } else if (param === 'external.terms_and_conditions') {
     value = 'http://www.yahoo.co.uk'
   }
 

--- a/tasks/gulp/build.js
+++ b/tasks/gulp/build.js
@@ -7,11 +7,14 @@ task('build:govuk-frontend', async () => {
   log(`${emoji.get('clipboard')}  ${green.bold('- Copying GOV.UK Frontend to package directory')}`)
   src(['node_modules/govuk-frontend/**'])
     .pipe(dest('package/govuk-frontend'))
+    .pipe(dest('src/govuk-frontend'))
 })
 
 task('build:digitalmarketplace', async () => {
   log(`${emoji.get('clipboard')}  ${green.bold('- Copying Digital Marketplace to package directory')}`)
   src(['src/digitalmarketplace/**',
-    '!**/*.test.js'])
+    '!**/*.test.js',
+    '!src/**/__snapshots__/**',
+    '!src/**/*.yaml'])
     .pipe(dest('package/digitalmarketplace'))
 })

--- a/tasks/gulp/clean.js
+++ b/tasks/gulp/clean.js
@@ -5,7 +5,7 @@ const { green } = require('chalk')
 const log = require('fancy-log')
 
 task('clean', async (done) => {
-  const deletedPaths = await del(['package/govuk-frontend'])
+  const deletedPaths = await del(['package/govuk-frontend', 'package/digitalmarketplace', 'src/govuk-frontend'])
   const colour = green.bold
   const logTitle = (deletedPaths.length) ? 'Deleted files and directories:\n' : 'No files/folders to clean'
   const logTitlePrefix = `${emoji.get('file_folder')}  - `


### PR DESCRIPTION
Ticket: https://trello.com/c/OYUBf016/

Inherits markup and styling from GOV.UK Frontend but allows us to pass in a standard set of options that will be used across all our frontend applications. 

## Test release
If you would like to test the component you can run this locally
`npm install --save alphagov/digitalmarketplace-govuk-frontend#def9e5b` and the frontend will need `dmutils v48.8.0` before following the directions in the [CHANGELOG](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/21/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1e).