### PR TITLE
Run build task on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "12"
   - "10"
+before_script:
+  - npm run build
 notifications:
   email: false
 sudo: false


### PR DESCRIPTION
Travis runs `npm test` by default but not build script. Github tests
were runing build and then test and passing where as Travis was failing
because build script had not been run.