### PR TITLE
Fix layout issues with error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+- Fix layout issues with error pages
+
+  Error pages content was not centrally aligned.
+
+  Check frontend app `config.py` includes `os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend', 'digitalmarketplace', 'templates'),` to lookup the error templates
+
+  Make sure `base_page.html` is using `mainContent` and `pageTitle` blocks
+
+  ([PR #23](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/23))
+
 ## 0.2.0
 
 🆕 New features:

--- a/src/digitalmarketplace/templates/errors/400.html
+++ b/src/digitalmarketplace/templates/errors/400.html
@@ -2,16 +2,14 @@
 
 {% block pageTitle %}Bad request - Digital Marketplace{% endblock %}
 
-{% block content %}
-  <div class="error-page">
-    <h1 class="govuk-heading-xl">Sorry, there was a problem with your request</h1>
+{% block mainContent %}
+  <h1 class="govuk-heading-xl">Sorry, there was a problem with your request</h1>
 
-    <p class="govuk-body">
-      {% if error_message %}
-        {{ error_message }}
-      {% else %}
-        Please do not attempt the same request again.
-      {% endif %}
-    </p>
-  </div>
+  <p class="govuk-body">
+    {% if error_message %}
+      {{ error_message }}
+    {% else %}
+      Please do not attempt the same request again.
+    {% endif %}
+  </p>
 {% endblock %}

--- a/src/digitalmarketplace/templates/errors/403.html
+++ b/src/digitalmarketplace/templates/errors/403.html
@@ -16,7 +16,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">You don’t have permission to perform this action</h1>
 
   <p class="govuk-body">

--- a/src/digitalmarketplace/templates/errors/404.html
+++ b/src/digitalmarketplace/templates/errors/404.html
@@ -2,15 +2,13 @@
 
 {% block pageTitle %}Page could not be found - Digital Marketplace{% endblock %}
 
-{% block content %}
-  <div class="error-page">
-    <h1 class="govuk-heading-xl">Page could not be found</h1>
+{% block mainContent %}
+  <h1 class="govuk-heading-xl">Page could not be found</h1>
 
-    <p class="govuk-body">
-      Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
-    </p>
-    <p class="govuk-body">
-      If you can’t find what you’re looking for, contact us at <a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
-    </p>
-  </div>
+  <p class="govuk-body">
+    Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
+  </p>
+  <p class="govuk-body">
+    If you can’t find what you’re looking for, contact us at <a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
+  </p>
 {% endblock %}

--- a/src/digitalmarketplace/templates/errors/410.html
+++ b/src/digitalmarketplace/templates/errors/410.html
@@ -2,15 +2,13 @@
 
 {% block pageTitle %}Service no longer available - Digital Marketplace{% endblock %}
 
-{% block content %}
-  <div class="error-page">
-    <h1 class="govuk-heading-xl">Page no longer available</h1>
+{% block mainContent %}
+  <h1 class="govuk-heading-xl">Page no longer available</h1>
 
-    <p class="govuk-body">
-      The page you requested is no longer available on the Digital Marketplace.
-    </p>
-    <p class="govuk-body">
-      If you can't find what you're looking for, email <a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
-    </p>
-  </div>
+  <p class="govuk-body">
+    The page you requested is no longer available on the Digital Marketplace.
+  </p>
+  <p class="govuk-body">
+    If you can't find what you're looking for, email <a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
+  </p>
 {% endblock %}

--- a/src/digitalmarketplace/templates/errors/500.html
+++ b/src/digitalmarketplace/templates/errors/500.html
@@ -2,16 +2,14 @@
 
 {% block pageTitle %}Sorry, we’re experiencing technical difficulties - Digital Marketplace{% endblock %}
 
-{% block content %}
-  <div class="error-page">
-    <h1 class="govuk-heading-xl">Sorry, we’re experiencing technical difficulties</h1>
+{% block mainContent %}
+  <h1 class="govuk-heading-xl">Sorry, we’re experiencing technical difficulties</h1>
 
-    <p class="govuk-body">
-      {% if error_message %}
-        {{ error_message }}
-      {% else %}
-        Try again later.
-      {% endif %}
-    </p>
-  </div>
+  <p class="govuk-body">
+    {% if error_message %}
+      {{ error_message }}
+    {% else %}
+      Try again later.
+    {% endif %}
+  </p>
 {% endblock %}


### PR DESCRIPTION
Error pages did not have their content centrally aligned.


### Before
![image](https://user-images.githubusercontent.com/3441519/68201780-56657380-ffba-11e9-938c-35168ae105a0.png)

### After
![image](https://user-images.githubusercontent.com/3441519/68205593-96c8ef80-ffc2-11e9-8306-94bf172e6bb9.png)

ticket: https://trello.com/c/T9hBnYM5

