### PR TITLE
New component: Digital Marketplace Header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+- New component: Digital Marketplace Header component
+
+  *Requirement before using this component:*
+  - To use this the application must be using `govuk-frontend` template
+  - To use this the application must be using `govuk-frontend` phase banner as phase tag
+    is no longer part of the header and sits underneath and outside the header
+
+  *Installing component:*
+  1. Check config.py has this line for jinja to find the components
+      ```
+                  os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend')
+      ```
+
+  2. Import the component in `_base_page.html`
+     `{% from "digitalmarketplace/components/header/macro.njk" import dmheader %}`
+
+  3. Use the component `{{ dmHeader({}) }}`
+
+  ([PR #25](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/25))
+
 - New component: Digital Marketplace Footer component
 
   *Requirement before using this component:*

--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -1,5 +1,6 @@
 $govuk-show-breakpoints: true;
 
 @import "govuk-frontend/all.scss";
+@import "digitalmarketplace/all.scss";
 @import "./partials/app";
 @import "./partials/banner";

--- a/src/digitalmarketplace/_all.scss
+++ b/src/digitalmarketplace/_all.scss
@@ -1,0 +1,1 @@
+@import "components/header/header";

--- a/src/digitalmarketplace/components/header/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/header/__snapshots__/template.test.js.snap
@@ -269,3 +269,55 @@ exports[`header when a user is not logged in renders a header component with all
 
 </body></html>"
 `;
+
+exports[`header when a user is signed out or not signed in specifically renders a header component with all our standard links 1`] = `
+"<html><head></head><body><header class=\\"govuk-header \\" role=\\"banner\\" data-module=\\"header\\">
+  <div class=\\"govuk-header__container govuk-width-container\\">
+
+    <div class=\\"govuk-header__logo\\">
+      <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+        <span class=\\"govuk-header__logotype\\">
+          
+          <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"32\\" width=\\"36\\">
+            <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"/>
+            
+            <image src=\\"/assets/images/govuk-logotype-crown.png\\" href=\\"\\" class=\\"govuk-header__logotype-crown-fallback-image\\" width=\\"36\\" height=\\"32\\"/>
+          </svg>
+          <span class=\\"govuk-header__logotype-text\\">
+            GOV.UK
+          </span>
+        </span>
+        <span class=\\"govuk-header__product-name\\">
+          Digital Marketplace
+        </span>
+      </a>
+    </div>
+    <div class=\\"govuk-header__content\\">
+
+
+    <button type=\\"button\\" role=\\"button\\" class=\\"govuk-header__menu-button js-header-toggle\\" aria-controls=\\"navigation\\" aria-label=\\"Show or hide Top Level Navigation\\">Menu</button>
+    <nav>
+      <ul id=\\"navigation\\" class=\\"govuk-header__navigation \\" aria-label=\\"Top Level Navigation\\">
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace\\">
+                Guidance
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.google.com\\">
+                Help
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.logmein.now\\">
+                Log in
+              </a>
+            </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
+
+</body></html>"
+`;

--- a/src/digitalmarketplace/components/header/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/header/__snapshots__/template.test.js.snap
@@ -1,0 +1,271 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`header admin or any other type of use is signed in renders a header component with all our standard links 1`] = `
+"<html><head></head><body><header class=\\"govuk-header \\" role=\\"banner\\" data-module=\\"header\\">
+  <div class=\\"govuk-header__container govuk-width-container\\">
+
+    <div class=\\"govuk-header__logo\\">
+      <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+        <span class=\\"govuk-header__logotype\\">
+          
+          <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"32\\" width=\\"36\\">
+            <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"/>
+            
+            <image src=\\"/assets/images/govuk-logotype-crown.png\\" href=\\"\\" class=\\"govuk-header__logotype-crown-fallback-image\\" width=\\"36\\" height=\\"32\\"/>
+          </svg>
+          <span class=\\"govuk-header__logotype-text\\">
+            GOV.UK
+          </span>
+        </span>
+        <span class=\\"govuk-header__product-name\\">
+          Digital Marketplace
+        </span>
+      </a>
+    </div>
+    <div class=\\"govuk-header__content\\">
+
+
+    <button type=\\"button\\" role=\\"button\\" class=\\"govuk-header__menu-button js-header-toggle\\" aria-controls=\\"navigation\\" aria-label=\\"Show or hide Top Level Navigation\\">Menu</button>
+    <nav>
+      <ul id=\\"navigation\\" class=\\"govuk-header__navigation \\" aria-label=\\"Top Level Navigation\\">
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace\\">
+                Guidance
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.google.com\\">
+                Help
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.logmeout.now\\">
+                Log out
+              </a>
+            </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
+
+</body></html>"
+`;
+
+exports[`header buyer signed in renders a header component with all our standard links 1`] = `
+"<html><head></head><body><header class=\\"govuk-header \\" role=\\"banner\\" data-module=\\"header\\">
+  <div class=\\"govuk-header__container govuk-width-container\\">
+
+    <div class=\\"govuk-header__logo\\">
+      <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+        <span class=\\"govuk-header__logotype\\">
+          
+          <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"32\\" width=\\"36\\">
+            <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"/>
+            
+            <image src=\\"/assets/images/govuk-logotype-crown.png\\" href=\\"\\" class=\\"govuk-header__logotype-crown-fallback-image\\" width=\\"36\\" height=\\"32\\"/>
+          </svg>
+          <span class=\\"govuk-header__logotype-text\\">
+            GOV.UK
+          </span>
+        </span>
+        <span class=\\"govuk-header__product-name\\">
+          Digital Marketplace
+        </span>
+      </a>
+    </div>
+    <div class=\\"govuk-header__content\\">
+
+
+    <button type=\\"button\\" role=\\"button\\" class=\\"govuk-header__menu-button js-header-toggle\\" aria-controls=\\"navigation\\" aria-label=\\"Show or hide Top Level Navigation\\">Menu</button>
+    <nav>
+      <ul id=\\"navigation\\" class=\\"govuk-header__navigation \\" aria-label=\\"Top Level Navigation\\">
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace\\">
+                Guidance
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.google.com\\">
+                Help
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.buyer.dashboard\\">
+                View your account
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.logmeout.now\\">
+                Log out
+              </a>
+            </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
+
+</body></html>"
+`;
+
+exports[`header component being used in admin frontend renders a header component with all our standard links 1`] = `
+"<html><head></head><body><header class=\\"govuk-header app-admin-header\\" role=\\"banner\\" data-module=\\"header\\">
+  <div class=\\"govuk-header__container govuk-width-container\\">
+
+    <div class=\\"govuk-header__logo\\">
+      <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+        <span class=\\"govuk-header__logotype\\">
+          
+          <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"32\\" width=\\"36\\">
+            <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"/>
+            
+            <image src=\\"/assets/images/govuk-logotype-crown.png\\" href=\\"\\" class=\\"govuk-header__logotype-crown-fallback-image\\" width=\\"36\\" height=\\"32\\"/>
+          </svg>
+          <span class=\\"govuk-header__logotype-text\\">
+            GOV.UK
+          </span>
+        </span>
+        <span class=\\"govuk-header__product-name\\">
+          Digital Marketplace Admin
+        </span>
+      </a>
+    </div>
+    <div class=\\"govuk-header__content\\">
+
+
+    <button type=\\"button\\" role=\\"button\\" class=\\"govuk-header__menu-button js-header-toggle\\" aria-controls=\\"navigation\\" aria-label=\\"Show or hide Top Level Navigation\\">Menu</button>
+    <nav>
+      <ul id=\\"navigation\\" class=\\"govuk-header__navigation \\" aria-label=\\"Top Level Navigation\\">
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace\\">
+                Guidance
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.google.com\\">
+                Help
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.logmein.now\\">
+                Log in
+              </a>
+            </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
+
+</body></html>"
+`;
+
+exports[`header supplier signed in renders a header component with all our standard links 1`] = `
+"<html><head></head><body><header class=\\"govuk-header \\" role=\\"banner\\" data-module=\\"header\\">
+  <div class=\\"govuk-header__container govuk-width-container\\">
+
+    <div class=\\"govuk-header__logo\\">
+      <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+        <span class=\\"govuk-header__logotype\\">
+          
+          <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"32\\" width=\\"36\\">
+            <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"/>
+            
+            <image src=\\"/assets/images/govuk-logotype-crown.png\\" href=\\"\\" class=\\"govuk-header__logotype-crown-fallback-image\\" width=\\"36\\" height=\\"32\\"/>
+          </svg>
+          <span class=\\"govuk-header__logotype-text\\">
+            GOV.UK
+          </span>
+        </span>
+        <span class=\\"govuk-header__product-name\\">
+          Digital Marketplace
+        </span>
+      </a>
+    </div>
+    <div class=\\"govuk-header__content\\">
+
+
+    <button type=\\"button\\" role=\\"button\\" class=\\"govuk-header__menu-button js-header-toggle\\" aria-controls=\\"navigation\\" aria-label=\\"Show or hide Top Level Navigation\\">Menu</button>
+    <nav>
+      <ul id=\\"navigation\\" class=\\"govuk-header__navigation \\" aria-label=\\"Top Level Navigation\\">
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace\\">
+                Guidance
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.google.com\\">
+                Help
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.supplier.dashboard\\">
+                View your account
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.logmeout.now\\">
+                Log out
+              </a>
+            </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
+
+</body></html>"
+`;
+
+exports[`header when a user is not logged in renders a header component with all our standard links 1`] = `
+"<html><head></head><body><header class=\\"govuk-header \\" role=\\"banner\\" data-module=\\"header\\">
+  <div class=\\"govuk-header__container govuk-width-container\\">
+
+    <div class=\\"govuk-header__logo\\">
+      <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+        <span class=\\"govuk-header__logotype\\">
+          
+          <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"32\\" width=\\"36\\">
+            <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"/>
+            
+            <image src=\\"/assets/images/govuk-logotype-crown.png\\" href=\\"\\" class=\\"govuk-header__logotype-crown-fallback-image\\" width=\\"36\\" height=\\"32\\"/>
+          </svg>
+          <span class=\\"govuk-header__logotype-text\\">
+            GOV.UK
+          </span>
+        </span>
+        <span class=\\"govuk-header__product-name\\">
+          Digital Marketplace
+        </span>
+      </a>
+    </div>
+    <div class=\\"govuk-header__content\\">
+
+
+    <button type=\\"button\\" role=\\"button\\" class=\\"govuk-header__menu-button js-header-toggle\\" aria-controls=\\"navigation\\" aria-label=\\"Show or hide Top Level Navigation\\">Menu</button>
+    <nav>
+      <ul id=\\"navigation\\" class=\\"govuk-header__navigation \\" aria-label=\\"Top Level Navigation\\">
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace\\">
+                Guidance
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.google.com\\">
+                Help
+              </a>
+            </li>
+            <li class=\\"govuk-header__navigation-item\\">
+              <a class=\\"govuk-header__link\\" href=\\"http://www.logmein.now\\">
+                Log in
+              </a>
+            </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
+
+</body></html>"
+`;

--- a/src/digitalmarketplace/components/header/_header.scss
+++ b/src/digitalmarketplace/components/header/_header.scss
@@ -1,0 +1,29 @@
+@import "../../../govuk-frontend/tools/all";
+@import "../../../govuk-frontend/helpers/all";
+
+@include govuk-exports("digitalmarketplace/component/header") {
+
+
+/* This file extends GOV.UK Frontend header component
+   by changing the blue bottom border to red and shifting
+   the navigation items to the far right.
+*/
+
+  .app-admin-header {
+    .govuk-header__container {
+      border-bottom-color: govuk-colour("red");
+    }
+  }
+
+  .govuk-header__logo {
+    width: auto;
+  }
+
+  .govuk-header__content {
+    @include govuk-media-query(desktop) {
+      width: auto;
+      float: none;
+      text-align: right;
+    }
+  }
+}

--- a/src/digitalmarketplace/components/header/header.yaml
+++ b/src/digitalmarketplace/components/header/header.yaml
@@ -1,0 +1,25 @@
+params:
+previewLayout: full-width
+examples:
+  - name: default
+    data:
+      isAdmin: false
+      logged_in: false
+  - name: for Admin Frontend
+    data:
+      isAdmin: true
+      logged_in: false
+  - name: for Buyer
+    data:
+      logged_in: true
+      role: 'buyer'
+  - name: for Supplier
+    data:
+      logged_in: true
+      role: 'supplier'
+  - name: for users in other roles
+    data:
+      logged_in: true
+      role: 'woodchucker'
+
+

--- a/src/digitalmarketplace/components/header/header.yaml
+++ b/src/digitalmarketplace/components/header/header.yaml
@@ -1,25 +1,31 @@
 params:
+- name: role
+  type: string
+  required: false
+  description: Used to determine whether a user is logged in or not. Could be set to "None" if the user is not logged in
+- name: isAdmin
+  type: boolean
+  required: false
+  description: Determines whether or not to apply a special css class to the component to give it a different coloured border to the original header component
 previewLayout: full-width
 examples:
   - name: default
     data:
       isAdmin: false
-      logged_in: false
   - name: for Admin Frontend
     data:
       isAdmin: true
-      logged_in: false
   - name: for Buyer
     data:
-      logged_in: true
       role: 'buyer'
   - name: for Supplier
     data:
-      logged_in: true
       role: 'supplier'
   - name: for users in other roles
     data:
-      logged_in: true
       role: 'woodchucker'
+  - name: for user who is not signed in
+    data:
+      role: null
 
 

--- a/src/digitalmarketplace/components/header/macro.njk
+++ b/src/digitalmarketplace/components/header/macro.njk
@@ -1,0 +1,3 @@
+{% macro dmHeader(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/digitalmarketplace/components/header/template.njk
+++ b/src/digitalmarketplace/components/header/template.njk
@@ -1,0 +1,85 @@
+{% from "../../../govuk-frontend/components/header/macro.njk" import govukHeader -%}
+
+{% set isAdmin = params.isAdmin | default(false) %}
+
+{% if isAdmin %}
+  {% set adminAppClass = 'app-admin-header' %}
+  {% set productName = 'Digital Marketplace Admin' %}
+{% else %}
+  {% set adminAppClass = '' %}
+  {% set productName = 'Digital Marketplace' %}
+{% endif %}
+
+{# current_user = global Flask object provided by a plugin called Flask-Login #}
+{# params.logged_in/role = used for testing or where current_user is not set #}
+
+{% if current_user %}
+  {% set user_logged_in = current_user.is_authenticated() if current_user.is_authenticated is callable else
+    current_user.is_authenticated %}
+{% else %}
+  {% set user_logged_in = params.logged_in | default(false, true) %}
+{% endif %}
+
+{% if user_logged_in %}
+  {% set users_role = (params.role or current_user.role) %}
+
+  {% if users_role in['buyer', 'supplier'] %}
+    {% set headerNavigation = [
+      {
+        'text': 'Guidance',
+        'href': 'https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace'
+      },
+      {
+        'text': 'Help',
+        'href': url_for('external.help')
+      },
+      {
+        'text': 'View your account',
+        'href': url_for('external.' + users_role + '_dashboard')
+      },
+      {
+        'text': 'Log out',
+        'href': url_for('external.user_logout')
+      }
+    ]%}
+  {% else %}
+    {# Any other role #}
+    {% set headerNavigation = [
+      {
+        'text': 'Guidance',
+        'href': 'https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace'
+      },
+      {
+        'text': 'Help',
+        'href': url_for('external.help')
+      },
+      {
+        'text': 'Log out',
+        'href': url_for('external.user_logout')
+      }
+    ]%}
+  {% endif %}
+{% else %}
+  {% set headerNavigation = [
+    {
+      'text': 'Guidance',
+      'href': 'https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace'
+    },
+    {
+      'text': 'Help',
+      'href': url_for('external.help')
+    },
+    {
+      'text': 'Log in',
+      'href': url_for('external.render_login')
+    }
+  ]%}
+{% endif %}
+{{
+  govukHeader({
+    'productName': productName,
+    'productUrl': '/',
+    'classes': adminAppClass,
+    'navigation': headerNavigation
+  })
+}}

--- a/src/digitalmarketplace/components/header/template.njk
+++ b/src/digitalmarketplace/components/header/template.njk
@@ -1,5 +1,8 @@
 {% from "../../../govuk-frontend/components/header/macro.njk" import govukHeader -%}
 
+{% set user_logged_in = true if params.role else false %}
+{% set users_role = params.role|default(none) %}
+
 {% set isAdmin = params.isAdmin | default(false) %}
 
 {% if isAdmin %}
@@ -10,18 +13,7 @@
   {% set productName = 'Digital Marketplace' %}
 {% endif %}
 
-{# current_user = global Flask object provided by a plugin called Flask-Login #}
-{# params.logged_in/role = used for testing or where current_user is not set #}
-
-{% if current_user %}
-  {% set user_logged_in = current_user.is_authenticated() if current_user.is_authenticated is callable else
-    current_user.is_authenticated %}
-{% else %}
-  {% set user_logged_in = params.logged_in | default(false, true) %}
-{% endif %}
-
 {% if user_logged_in %}
-  {% set users_role = (params.role or current_user.role) %}
 
   {% if users_role in['buyer', 'supplier'] %}
     {% set headerNavigation = [

--- a/src/digitalmarketplace/components/header/template.test.js
+++ b/src/digitalmarketplace/components/header/template.test.js
@@ -1,0 +1,127 @@
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers.js')
+
+const examples = getExamples('header')
+
+const urlForMock = jest.fn((param) => {
+  let value = ''
+  if (param === 'external.help') {
+    value = 'http://www.google.com'
+  } else if (param === 'external.render_login') {
+    value = 'http://www.logmein.now'
+  } else if (param === 'external.buyer_dashboard') {
+    value = 'http://www.buyer.dashboard'
+  } else if (param === 'external.supplier_dashboard') {
+    value = 'http://www.supplier.dashboard'
+  } else if (param === 'external.user_logout') {
+    value = 'http://www.logmeout.now'
+  }
+
+  return value
+})
+
+let mockedMethods
+
+describe('header', () => {
+  describe('when a user is not logged in', () => {
+    beforeAll(() => {
+      mockedMethods = {
+        url_for: urlForMock
+      }
+    })
+
+    it('default example passes accessibility tests', async () => {
+      const $ = render('header', examples.default, mockedMethods)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+    it('renders a header component with all our standard links', () => {
+      const $ = render('header', examples.default, mockedMethods)
+      expect($.html()).toMatchSnapshot()
+    })
+  })
+
+  describe('buyer signed in', () => {
+    beforeAll(() => {
+      mockedMethods = {
+        url_for: urlForMock
+      }
+    })
+
+    it('default example passes accessibility tests', async () => {
+      const $ = render('header', examples['for Buyer'], mockedMethods)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+    it('renders a header component with all our standard links', () => {
+      const $ = render('header', examples['for Buyer'], mockedMethods)
+      expect($.html()).toMatchSnapshot()
+    })
+  })
+
+  describe('supplier signed in', () => {
+    beforeAll(() => {
+      mockedMethods = {
+        url_for: urlForMock
+      }
+    })
+
+    it('default example passes accessibility tests', async () => {
+      const $ = render('header', examples['for Supplier'], mockedMethods)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+    it('renders a header component with all our standard links', () => {
+      const $ = render('header', examples['for Supplier'], mockedMethods)
+      expect($.html()).toMatchSnapshot()
+    })
+  })
+
+  describe('admin or any other type of use is signed in', () => {
+    beforeAll(() => {
+      mockedMethods = {
+        url_for: urlForMock
+      }
+    })
+
+    it('default example passes accessibility tests', async () => {
+      const $ = render('header', examples['for users in other roles'], mockedMethods)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+    it('renders a header component with all our standard links', () => {
+      const $ = render('header', examples['for users in other roles'], mockedMethods)
+      expect($.html()).toMatchSnapshot()
+    })
+  })
+
+  describe('component being used in admin frontend', () => {
+    beforeAll(() => {
+      mockedMethods = {
+        url_for: urlForMock
+      }
+    })
+
+    it('default example passes accessibility tests', async () => {
+      const $ = render('header', examples['for Admin Frontend'], mockedMethods)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a header component with all our standard links', () => {
+      const $ = render('header', examples['for Admin Frontend'], mockedMethods)
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders a header component with a custom class to style the bottom border', () => {
+      const $ = render('header', examples['for Admin Frontend'], mockedMethods)
+      expect($('header.govuk-header.app-admin-header').length).toBe(1)
+    })
+  })
+})

--- a/src/digitalmarketplace/components/header/template.test.js
+++ b/src/digitalmarketplace/components/header/template.test.js
@@ -124,4 +124,24 @@ describe('header', () => {
       expect($('header.govuk-header.app-admin-header').length).toBe(1)
     })
   })
+
+  describe('when a user is signed out or not signed in specifically', () => {
+    beforeAll(() => {
+      mockedMethods = {
+        url_for: urlForMock
+      }
+    })
+
+    it('default example passes accessibility tests', async () => {
+      const $ = render('header', examples['for user who is not signed in'], mockedMethods)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a header component with all our standard links', () => {
+      const $ = render('header', examples['for user who is not signed in'], mockedMethods)
+      expect($.html()).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
We would have just used GOV.UK Frontend header component but we needed
to customize it specifically for Digital Martketplace.

1. Navigation links position - we needed to the style of all the applications
   to look consistent while we roll out govuk-frontend. Therefore we needed
   the navigation to be right-aligned and the service name to be positioned
   next to the crown.

2. Admin frontend - For Admin frontend we wanted to use a different header so
   users could see they were no longer in the main application. To do this we 
   added `Admin` to the end of the product name and there is still the red border

## Usage:

1. Import the component
2. Call the component using 
```
	{{ dmHeader({ 
		"role": current_user|default(None)
	}) }}
```
3. For Admin frontend use 
```
	{{ dmHeader({
		"isAdmin": "true", 
		"role": current_user|default(None)}) 
	}}
```

## What does the thing look like?
![image](https://user-images.githubusercontent.com/3441519/69865889-72e38b80-129a-11ea-9184-cacf85adf226.png)



Ticket: https://trello.com/c/XO7Tfx8f/134-add-header-component-to-digital-marketplace-govuk-frontend
