### PR TITLE
Remove gulp-rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5249,12 +5249,6 @@
         "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
-    "gulp-rename": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
-      "integrity": "sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==",
-      "dev": true
-    },
     "gulp-sass": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "cssnano": "^4.1.10",
     "express": "^4.17.1",
     "gulp-plumber": "^1.2.1",
-    "gulp-rename": "^1.4.0",
     "gulp-sass": "^4.0.2",
     "jest": "^24.9.0",
     "jest-axe": "^3.2.0",


### PR DESCRIPTION
We are not currently using this anywhere, we should remove it.