### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
We've been using dependabot to keep JavaScript dependencies up-to-date in this repo, but the configuration has been done through the dashboard.

This PR adds a minimal dependabot configuration file, so that it's clear in the repo what the dependabot configuration is.

Also, it changes the update schedule to weekly, to be in line with our PyUp PRs.