### PR TITLE
fix header class prefix from app to dm

### DIFF
--- a/src/digitalmarketplace/components/header/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/header/__snapshots__/template.test.js.snap
@@ -110,7 +110,7 @@ exports[`header buyer signed in renders a header component with all our standard
 `;
 
 exports[`header component being used in admin frontend renders a header component with all our standard links 1`] = `
-"<html><head></head><body><header class=\\"govuk-header app-admin-header\\" role=\\"banner\\" data-module=\\"header\\">
+"<html><head></head><body><header class=\\"govuk-header dm-admin-header\\" role=\\"banner\\" data-module=\\"header\\">
   <div class=\\"govuk-header__container govuk-width-container\\">
 
     <div class=\\"govuk-header__logo\\">

--- a/src/digitalmarketplace/components/header/_header.scss
+++ b/src/digitalmarketplace/components/header/_header.scss
@@ -9,7 +9,7 @@
    the navigation items to the far right.
 */
 
-  .app-admin-header {
+  .dm-admin-header {
     .govuk-header__container {
       border-bottom-color: govuk-colour("red");
     }

--- a/src/digitalmarketplace/components/header/template.njk
+++ b/src/digitalmarketplace/components/header/template.njk
@@ -6,7 +6,7 @@
 {% set isAdmin = params.isAdmin | default(false) %}
 
 {% if isAdmin %}
-  {% set adminAppClass = 'app-admin-header' %}
+  {% set adminAppClass = 'dm-admin-header' %}
   {% set productName = 'Digital Marketplace Admin' %}
 {% else %}
   {% set adminAppClass = '' %}

--- a/src/digitalmarketplace/components/header/template.test.js
+++ b/src/digitalmarketplace/components/header/template.test.js
@@ -121,7 +121,7 @@ describe('header', () => {
 
     it('renders a header component with a custom class to style the bottom border', () => {
       const $ = render('header', examples['for Admin Frontend'], mockedMethods)
-      expect($('header.govuk-header.app-admin-header').length).toBe(1)
+      expect($('header.govuk-header.dm-admin-header').length).toBe(1)
     })
   })
 


### PR DESCRIPTION
`app` should only be used by the frontend application itself and not
any component library. To be consistent, I have corrected this by replacing
`app-` prefix with `dm-` prefix. This should not break anything as this
component has not been officially released or used in any of our
applicaitons