### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Update release script
 
   We changed the release process but did not update the script as a result we had
-  unpublish v0.3.0 from npm.
+  to unpublish v0.3.0 from npm.
 
   ([PR #42](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/42))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+## 0.3.1
+
+🔧 Fixes:
+
+- Update release script
+
+  We changed the release process but did not update the script as a result we had
+  unpublish v0.3.0 from npm.
+
+  ([PR #42](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/42))
+
 ## 0.3.0
 
 🆕 New features:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
## Changelog

🔧 Fixes:

- Update release script

  We changed the release process but did not update the script as a result we had
  unpublish v0.3.0 from npm.

  ([PR #42](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/42))