### PR TITLE
Fix readme for alert component

### DIFF
--- a/src/digitalmarketplace/components/alert/alert.yaml
+++ b/src/digitalmarketplace/components/alert/alert.yaml
@@ -2,7 +2,7 @@ params:
 - name: type
   type: string
   required: true
-  description: Defines which type of alert will be rendered. The options are alert (red), notice (blue) and success (green).
+  description: Defines which type of alert will be rendered. The options are error (red), notice (blue) and success (green).
 - name: titleText
   type: string
   required: true


### PR DESCRIPTION
Correct typo, alert type `alert` is actually `error`.