### PR TITLE
Change link to supplier A to Z

### DIFF
--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -34,7 +34,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
                     </li>
                     <li class=\\"govuk-footer__list-item\\">
                       <a class=\\"govuk-footer__link\\" href=\\"http://www.gov.uk\\">
-                        G-Cloud supplier A-Z
+                        G-Cloud supplier A to Z
                       </a>
                     </li>
               </ul>

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -26,7 +26,7 @@
         },
         {
           href: url_for('external.suppliers_list_by_prefix'),
-          text: 'G-Cloud supplier A-Z'
+          text: 'G-Cloud supplier A to Z'
         }
       ]
     },


### PR DESCRIPTION
@NoraGDS pointed out that `A to Z` is more readable and accessible than `A-Z`.

Ticket: https://trello.com/c/i4eJBbNC/274-replace-content-supplier-a-z-with-supplier-a-to-z

### Screenshots

#### Before

![Footer with 'G-Cloud supplier A-Z'](https://user-images.githubusercontent.com/503614/73362082-17d01400-429e-11ea-87b2-db94d888610d.png)

#### After

![Footer with 'G-Cloud supplier A to Z'](https://user-images.githubusercontent.com/503614/73362133-31715b80-429e-11ea-8860-0d3e2d90d737.png)
