### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+## 0.4.1
+
+🔧 Fixes:
+
+- Change link text for G-Cloud supplier A to Z link in footer
+
+  ([PR 55](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/55))
+
 ## 0.4.0
 
 🆕 New features:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
🔧 Fixes:

- Change link text for G-Cloud supplier A to Z link in footer

  ([PR 55](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/55))