### PR TITLE
Fix option name in header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
   ([PR #N](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/N))
 
+- Fix option in header component
+
+  ([PR #58](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/58))
+
 ## 0.4.1
 
 🔧 Fixes:

--- a/src/digitalmarketplace/components/header/template.njk
+++ b/src/digitalmarketplace/components/header/template.njk
@@ -70,7 +70,7 @@
 {{
   govukHeader({
     'productName': productName,
-    'productUrl': '/',
+    'homepageUrl': '/',
     'classes': adminAppClass,
     'navigation': headerNavigation
   })


### PR DESCRIPTION
Nunjucks macro option `productUrl` should be `homepageUrl`.

This actually doesn't matter because the default for `homepageUrl` is `/`, which is what we wanted; best to have it right anyway :)