### PR TITLE
Cookie settings page JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+🆕 New features:
+
+- New component: Cookie settings page javascript
+
+  - Allows a user to set their analytics cookie preferences
+
 🔧 Fixes:
 
 - Use dm_cookies_policy to be in line with our other custom cookies

--- a/src/digitalmarketplace/all.js
+++ b/src/digitalmarketplace/all.js
@@ -1,4 +1,5 @@
 import CookieBanner from './components/cookie-banner/cookie-banner'
+import CookieSettings from './components/cookie-settings/cookie-settings'
 import * as Analytics from './components/analytics/analytics'
 import initAnalytics from './components/analytics/init'
 
@@ -7,11 +8,16 @@ function initAll (options) {
   if ($cookieBanner) {
     new CookieBanner($cookieBanner).init()
   }
+  const $cookieSettingsPage = document.querySelector('[data-module="dm-cookie-settings"]')
+  if ($cookieSettingsPage) {
+    new CookieSettings($cookieSettingsPage).init()
+  }
 }
 
 export {
   initAll,
   initAnalytics,
   Analytics,
-  CookieBanner
+  CookieBanner,
+  CookieSettings
 }

--- a/src/digitalmarketplace/components/cookie-settings/README.md
+++ b/src/digitalmarketplace/components/cookie-settings/README.md
@@ -1,0 +1,27 @@
+# Cookie Settings page
+
+This component includes Javascript only, for use the User Frontend Cookie Settings page.
+
+## Functionality
+On page load:
+- adds an event listener to the Cookie Settings form to handle any submit actions
+- checks for any existing `dm_cookies_policy` cookie
+- populates the Cookie Settings form with the user's existing preferences (if cookie has been set)
+- displays a warning message if the user has not set any analytics preferences
+- hides the Cookie Banner component if present (to avoid confusion for the user)
+
+On submitting the form:
+- sets a `dm_cookies_policy` cookie containing the user's analytics preferences (true or false)
+- displays a confirmation message
+- displays an error message if the user submitted an empty form
+- (if user chooses to accept analytics) initialises Google Analytics cookies and sends an initial TrackPageview event
+- (if user chooses to reject analytics) disables Google Analytics and deletes any existing Google Analytics cookies,
+via the `setConsentCookie` helper function
+
+
+## Installation
+Install by including the following line in the app's `application.js`:
+
+```
+DMGOVUKFrontend.initAll()
+```

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -1,0 +1,129 @@
+// Javascript code to support the Cookie Settings page
+import { getCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
+import InitialiseAnalytics from '../analytics/init'
+
+export function CookieSettings ($module) {
+  this.$module = $module
+}
+
+CookieSettings.prototype.init = function () {
+  this.$module.submitSettingsForm = this.submitSettingsForm.bind(this)
+
+  this.$module.addEventListener('submit', this.$module.submitSettingsForm)
+
+  // Ensure there aren't two forms for setting cookie preferences on the same page
+  this.hideCookieBanner()
+
+  this.setInitialFormValues()
+}
+
+CookieSettings.prototype.setInitialFormValues = function () {
+  var currentConsentCookie = getCookie('dm_cookies_policy')
+
+  if (!currentConsentCookie) {
+    // Don't populate the form
+    return
+  }
+
+  this.hideWarningMessage()
+
+  // Populate the form with the existing choice
+  var radioButton
+  if (currentConsentCookie.analytics) {
+    radioButton = this.$module.querySelector('input[name=cookies-analytics][value=On]')
+  } else {
+    radioButton = this.$module.querySelector('input[name=cookies-analytics][value=Off]')
+  }
+  radioButton.checked = true
+}
+
+CookieSettings.prototype.submitSettingsForm = function (event) {
+  event.preventDefault()
+
+  var formInputs = event.target.querySelectorAll('input[name=cookies-analytics]')
+  var options = {}
+
+  // Retrieve the selected value from the form inputs
+  for (var i = 0; i < formInputs.length; i++) {
+    var input = formInputs[i]
+    if (input.checked) {
+      var value = input.value === 'On'
+
+      options.analytics = value
+      break
+    }
+  }
+  // the cookie choice must be set when form is submitted
+  if (options.analytics === undefined) {
+    this.showErrorMessage()
+    return false
+  }
+
+  // Set the analytics cookie preferences
+  // If 'Off' option not checked, this function will also delete any existing Google Analytics cookies
+  setConsentCookie(options)
+
+  // If 'On' option checked and analytics not yet present,
+  // initialise Analytics (this includes firing the initial pageview)
+  if (options.analytics && !window.DMGOVUKFrontend.analytics) {
+    InitialiseAnalytics()
+  }
+
+  this.hideWarningMessage()
+  this.hideErrorMessage()
+  this.showConfirmationMessage()
+
+  return false
+}
+
+CookieSettings.prototype.showConfirmationMessage = function () {
+  var confirmationMessage = document.querySelector('#cookie-settings-confirmation')
+  var previousPageLink = document.querySelector('.cookie-settings__prev-page')
+  var referrer = CookieSettings.prototype.getReferrerLink()
+
+  document.body.scrollTop = document.documentElement.scrollTop = 0
+
+  if (referrer && referrer !== document.location.pathname) {
+    previousPageLink.href = referrer
+    previousPageLink.style.display = 'block'
+  } else {
+    previousPageLink.style.display = 'none'
+  }
+
+  confirmationMessage.style.display = 'block'
+}
+
+CookieSettings.prototype.showErrorMessage = function () {
+  var errorMessage = document.querySelector('div#cookie-settings-error')
+  if (errorMessage !== null) {
+    errorMessage.style.display = 'block'
+    document.body.scrollTop = document.documentElement.scrollTop = 0
+  }
+}
+
+CookieSettings.prototype.hideErrorMessage = function () {
+  var errorMessage = document.querySelector('div#cookie-settings-error')
+  if (errorMessage !== null) {
+    errorMessage.style.display = 'none'
+  }
+}
+
+CookieSettings.prototype.hideWarningMessage = function () {
+  var warningMessage = document.querySelector('div#cookie-settings-warning')
+  if (warningMessage !== null) {
+    warningMessage.style.display = 'none'
+  }
+}
+
+CookieSettings.prototype.hideCookieBanner = function () {
+  var cookieBanner = document.querySelector('.dm-cookie-banner')
+  if (cookieBanner !== null) {
+    cookieBanner.style.display = 'none'
+  }
+}
+
+CookieSettings.prototype.getReferrerLink = function () {
+  return document.referrer ? new URL(document.referrer).pathname : false
+}
+
+export default CookieSettings

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -77,8 +77,8 @@ CookieSettings.prototype.submitSettingsForm = function (event) {
 }
 
 CookieSettings.prototype.showConfirmationMessage = function () {
-  var confirmationMessage = document.querySelector('#cookie-settings-confirmation')
-  var previousPageLink = document.querySelector('.cookie-settings__prev-page')
+  var confirmationMessage = document.querySelector('#dm-cookie-settings-confirmation')
+  var previousPageLink = document.querySelector('.dm-cookie-settings__prev-page')
   var referrer = CookieSettings.prototype.getReferrerLink()
 
   document.body.scrollTop = document.documentElement.scrollTop = 0
@@ -94,7 +94,7 @@ CookieSettings.prototype.showConfirmationMessage = function () {
 }
 
 CookieSettings.prototype.showErrorMessage = function () {
-  var errorMessage = document.querySelector('div#cookie-settings-error')
+  var errorMessage = document.querySelector('#dm-cookie-settings-error')
   if (errorMessage !== null) {
     errorMessage.style.display = 'block'
     document.body.scrollTop = document.documentElement.scrollTop = 0
@@ -102,14 +102,14 @@ CookieSettings.prototype.showErrorMessage = function () {
 }
 
 CookieSettings.prototype.hideErrorMessage = function () {
-  var errorMessage = document.querySelector('div#cookie-settings-error')
+  var errorMessage = document.querySelector('#dm-cookie-settings-error')
   if (errorMessage !== null) {
     errorMessage.style.display = 'none'
   }
 }
 
 CookieSettings.prototype.hideWarningMessage = function () {
-  var warningMessage = document.querySelector('div#cookie-settings-warning')
+  var warningMessage = document.querySelector('#dm-cookie-settings-warning')
   if (warningMessage !== null) {
     warningMessage.style.display = 'none'
   }

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as CookieHelpers from '../../helpers/cookie/cookie-functions'
+import InitialiseAnalytics from '../analytics/init'
+import CookieSettings from './cookie-settings'
+
+jest.mock('../../helpers/cookie/cookie-functions')
+jest.mock('../analytics/init')
+
+const formInputsForMock = jest.fn((param) => {
+  // Return the form input objects
+  let inputs = []
+  if (param === 'On') {
+    inputs = [{ checked: true, value: 'On' }, { value: 'Off' }]
+  } else if (param === 'Off') {
+    inputs = [{ checked: true, value: 'Off' }, { value: 'On' }]
+  } else if (param === 'Neither') {
+    inputs = [{ value: 'On' }, { value: 'Off' }]
+  }
+  return inputs
+})
+
+const mockSubmitEvent = jest.fn((param) => {
+  const submitEvent = jest.fn()
+  submitEvent.target = jest.fn()
+  submitEvent.preventDefault = jest.fn()
+  submitEvent.target.querySelectorAll = jest.fn()
+  submitEvent.target.querySelectorAll.mockImplementation(() => {
+    return formInputsForMock(param)
+  })
+  return submitEvent
+})
+
+let cookieSettingsForm
+
+beforeEach(() => {
+  // Delete any existing cookies
+  CookieHelpers.setCookie('dm_cookies_policy', null)
+
+  cookieSettingsForm = document.createElement('form')
+  cookieSettingsForm.setAttribute('id', 'dm-cookie-settings')
+  const inputOn = '<input type="radio" name="cookies-analytics" value=On />'
+  const inputOff = '<input type="radio" name="cookies-analytics" value=Off />'
+  const submitButton = '<button type="submit">Save cookie settings</button>'
+  const formInnerHTML = inputOn + inputOff + submitButton
+  cookieSettingsForm.innerHTML = formInnerHTML
+})
+
+afterEach(() => {
+  CookieHelpers.setConsentCookie.mockClear()
+  CookieHelpers.getCookie.mockClear()
+  InitialiseAnalytics.mockClear()
+})
+
+describe('Cookie settings', () => {
+  describe('initialising the component', () => {
+    it('hides the cookie banner if present', async () => {
+      const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+      $cookieSettings.hideCookieBanner = jest.fn()
+
+      await $cookieSettings.init()
+
+      expect($cookieSettings.hideCookieBanner).toHaveBeenCalled()
+    })
+
+    it('initialises form values', async () => {
+      const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+      $cookieSettings.setInitialFormValues = jest.fn()
+
+      await $cookieSettings.init()
+
+      expect($cookieSettings.setInitialFormValues).toHaveBeenCalled()
+    })
+
+    describe('without existing analytics', () => {
+      it('does not hide the warning message', async () => {
+        const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+        $cookieSettings.hideWarningMessage = jest.fn()
+
+        await $cookieSettings.init()
+
+        expect($cookieSettings.hideWarningMessage).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('with existing analytics', () => {
+      beforeEach(async () => {
+        CookieHelpers.getCookie.mockImplementation(() => {
+          return { dm_cookies_policy: { analytics: true } }
+        })
+      })
+
+      it('hides the warning message', async () => {
+        const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+        $cookieSettings.hideWarningMessage = jest.fn()
+
+        await $cookieSettings.init()
+
+        expect($cookieSettings.hideWarningMessage).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Submitting the form', () => {
+    beforeEach(async () => {
+      document.querySelector = jest.fn()
+      // Create a fake element to get/set display attribute
+      document.querySelector.mockImplementation(() => { return { style: {} } })
+    })
+
+    describe('with No selected', () => {
+      let submitEvent
+      beforeEach(async () => {
+        submitEvent = mockSubmitEvent('Off')
+      })
+
+      it('sets consent cookie', async () => {
+        await new CookieSettings(cookieSettingsForm).submitSettingsForm(submitEvent)
+        expect(submitEvent.preventDefault).toHaveBeenCalled()
+        expect(CookieHelpers.setConsentCookie).toHaveBeenCalledWith({ analytics: false })
+      })
+
+      it('does not initialise Analytics', async () => {
+        await new CookieSettings(cookieSettingsForm).submitSettingsForm(submitEvent)
+        expect(InitialiseAnalytics).not.toHaveBeenCalled()
+      })
+
+      it('shows confirmation message and hides other messages', async () => {
+        const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+        $cookieSettings.hideWarningMessage = jest.fn()
+        $cookieSettings.hideErrorMessage = jest.fn()
+        $cookieSettings.showConfirmationMessage = jest.fn()
+
+        await $cookieSettings.submitSettingsForm(submitEvent)
+
+        expect($cookieSettings.hideWarningMessage).toHaveBeenCalled()
+        expect($cookieSettings.hideErrorMessage).toHaveBeenCalled()
+        expect($cookieSettings.showConfirmationMessage).toHaveBeenCalled()
+      })
+    })
+
+    describe('with Yes selected', () => {
+      let submitEvent
+      beforeEach(async () => {
+        submitEvent = mockSubmitEvent('On')
+      })
+
+      it('sets consent cookie', async () => {
+        await new CookieSettings(cookieSettingsForm).submitSettingsForm(submitEvent)
+        expect(submitEvent.preventDefault).toHaveBeenCalled()
+        expect(CookieHelpers.setConsentCookie).toHaveBeenCalledWith({ analytics: true })
+      })
+
+      it('initialises Analytics', async () => {
+        await new CookieSettings(cookieSettingsForm).submitSettingsForm(submitEvent)
+        expect(InitialiseAnalytics).toHaveBeenCalled()
+      })
+
+      it('shows confirmation message and hides other messages', async () => {
+        const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+        $cookieSettings.hideWarningMessage = jest.fn()
+        $cookieSettings.hideErrorMessage = jest.fn()
+        $cookieSettings.showConfirmationMessage = jest.fn()
+
+        await $cookieSettings.submitSettingsForm(submitEvent)
+
+        expect($cookieSettings.hideWarningMessage).toHaveBeenCalled()
+        expect($cookieSettings.hideErrorMessage).toHaveBeenCalled()
+        expect($cookieSettings.showConfirmationMessage).toHaveBeenCalled()
+      })
+    })
+
+    describe('with nothing selected', () => {
+      let submitEvent
+      beforeEach(async () => {
+        submitEvent = mockSubmitEvent('Neither')
+      })
+
+      it('does not set consent cookie', async () => {
+        await new CookieSettings(cookieSettingsForm).submitSettingsForm(submitEvent)
+        expect(submitEvent.preventDefault).toHaveBeenCalled()
+        expect(CookieHelpers.setConsentCookie).not.toHaveBeenCalled()
+      })
+
+      it('does not initialise Analytics', async () => {
+        await new CookieSettings(cookieSettingsForm).submitSettingsForm(submitEvent)
+        expect(InitialiseAnalytics).not.toHaveBeenCalled()
+      })
+
+      it('shows error message', async () => {
+        const $cookieSettings = await new CookieSettings(cookieSettingsForm)
+        $cookieSettings.showErrorMessage = jest.fn()
+
+        await $cookieSettings.submitSettingsForm(submitEvent)
+
+        expect($cookieSettings.showErrorMessage).toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

Based largely on the equivalent Notify code (https://github.com/alphagov/notifications-admin/pull/3238).

Follows the structure, initialisation and import patterns of the Cookie Banner component. However, this component is Javascript-only - there's no template to include or test. As such the jest tests are limited to asserting stubbed out methods. Detailed behaviour tests for integration with the form itself will be added in the User FE.

See the component's README file for expected behaviour of this code.