### PR TITLE
Add 'dm' namespacing to our cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-See Changelog Examples at the bottom of this page.
+🔧 Fixes:
+
+- Use dm_cookies_policy to be in line with our other custom cookies
+- Use template parameters for Cookie Settings URL and Cookie Info URL
+- Banner should not be displayed on the Cookie Settings page
+
+  ([PR #62](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/62))
 
 ## 0.5.0
 

--- a/src/digitalmarketplace/components/cookie-banner/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/cookie-banner/__snapshots__/template.test.js.snap
@@ -22,7 +22,7 @@ exports[`cookie-banner component renders a cookie banner with visible content an
 
   <div class=\\"dm-cookie-banner__confirmation\\" tabindex=\\"-1\\">
     <p class=\\"dm-cookie-banner__confirmation-message govuk-body\\">
-      You can <a class=\\"govuk-link\\" href=\\"/cookies\\">change your cookie settings</a> at any time.
+      You can <a class=\\"govuk-link\\" href=\\"/user/cookie-settings\\">change your cookie settings</a> at any time.
     </p>
     <button class=\\"dm-cookie-banner__hide-button govuk-link\\" data-hide-cookie-banner=\\"true\\" role=\\"link\\">Hide</button>
   </div>

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
@@ -1,6 +1,8 @@
 import { getCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
 import InitialiseAnalytics from '../analytics/init'
 
+const cookieSettingsUrl = '/user/cookie-settings'
+
 const CookieBanner = function ($module) {
   this.$module = $module
 }
@@ -48,8 +50,8 @@ CookieBanner.prototype.setupCookieMessage = function () {
 }
 
 CookieBanner.prototype.showCookieMessage = function () {
-  // Show the cookie banner if not in the cookie settings page
-  if (!this.isInCookiesPage()) {
+  // Show the cookie banner if policy cookie not set AND not on the cookie settings page
+  if (!this.isInCookieSettingsPage()) {
     var hasCookiesPolicy = getCookie('dm_cookies_policy')
 
     if (this.$module && !hasCookiesPolicy) {
@@ -88,8 +90,8 @@ CookieBanner.prototype.showConfirmationMessage = function (analyticsConsent) {
   this.$module.cookieBannerConfirmationMessage.style.display = 'block'
 }
 
-CookieBanner.prototype.isInCookiesPage = function () {
-  return window.location.pathname === '/cookies'
+CookieBanner.prototype.isInCookieSettingsPage = function () {
+  return window.location.pathname === cookieSettingsUrl
 }
 
 export default CookieBanner

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
@@ -50,7 +50,7 @@ CookieBanner.prototype.setupCookieMessage = function () {
 CookieBanner.prototype.showCookieMessage = function () {
   // Show the cookie banner if not in the cookie settings page
   if (!this.isInCookiesPage()) {
-    var hasCookiesPolicy = getCookie('cookies_policy')
+    var hasCookiesPolicy = getCookie('dm_cookies_policy')
 
     if (this.$module && !hasCookiesPolicy) {
       this.$module.style.display = 'block'

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
@@ -1,8 +1,6 @@
 import { getCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
 import InitialiseAnalytics from '../analytics/init'
 
-const cookieSettingsUrl = '/user/cookie-settings'
-
 const CookieBanner = function ($module) {
   this.$module = $module
 }
@@ -50,13 +48,11 @@ CookieBanner.prototype.setupCookieMessage = function () {
 }
 
 CookieBanner.prototype.showCookieMessage = function () {
-  // Show the cookie banner if policy cookie not set AND not on the cookie settings page
-  if (!this.isInCookieSettingsPage()) {
-    var hasCookiesPolicy = getCookie('dm_cookies_policy')
+  // Show the cookie banner if policy cookie not set
+  var hasCookiesPolicy = getCookie('dm_cookies_policy')
 
-    if (this.$module && !hasCookiesPolicy) {
-      this.$module.style.display = 'block'
-    }
+  if (this.$module && !hasCookiesPolicy) {
+    this.$module.style.display = 'block'
   }
 }
 
@@ -88,10 +84,6 @@ CookieBanner.prototype.showConfirmationMessage = function (analyticsConsent) {
   this.$cookieBannerConfirmationMessage.insertAdjacentText('afterbegin', messagePrefix)
   this.$cookieBannerMainContent.style.display = 'none'
   this.$module.cookieBannerConfirmationMessage.style.display = 'block'
-}
-
-CookieBanner.prototype.isInCookieSettingsPage = function () {
-  return window.location.pathname === cookieSettingsUrl
 }
 
 export default CookieBanner

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.test.js
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.test.js
@@ -42,7 +42,7 @@ describe('cookie-banner new user', () => {
 
 describe('cookie-banner returning user', () => {
   it('with consent cookie set should not see the cookie banner', async () => {
-    const cookie = { name: 'cookies_policy', value: '{"analytics": true }' }
+    const cookie = { name: 'dm_cookies_policy', value: '{"analytics": true }' }
 
     await goToAndGetComponent('cookie-banner', { cookie })
     await page.setCookie(cookie) // set cookies to browser to pretend that user has agreed
@@ -53,7 +53,7 @@ describe('cookie-banner returning user', () => {
   })
 
   it('with consent cookie set to accept analytics should have analytics enabled', async () => {
-    const cookie = { name: 'cookies_policy', value: '{"analytics": true }' }
+    const cookie = { name: 'dm_cookies_policy', value: '{"analytics": true }' }
     await goToAndGetComponent('cookie-banner')
     await page.setCookie(cookie) // set cookies to browser to pretend that user has agreed
     await page.reload() // reload the page
@@ -64,7 +64,7 @@ describe('cookie-banner returning user', () => {
   })
 
   it('with consent cookie set to reject analytics should not have analytics enabled', async () => {
-    const cookie = { name: 'cookies_policy', value: '{"analytics": false }' }
+    const cookie = { name: 'dm_cookies_policy', value: '{"analytics": false }' }
     await goToAndGetComponent('cookie-banner')
     await page.setCookie(cookie) // set cookies to browser to pretend that user has agreed
     await page.reload() // reload the page
@@ -77,7 +77,7 @@ describe('cookie-banner returning user', () => {
 describe('cookie-banner new user', () => {
   describe('cookie-banner accepting analytics', () => {
     beforeEach(async () => {
-      await page.deleteCookie({ name: 'cookies_policy' })
+      await page.deleteCookie({ name: 'dm_cookies_policy' })
       await page.deleteCookie({ name: '_gid' })
       await page.deleteCookie({ name: '_ga' })
 
@@ -92,7 +92,7 @@ describe('cookie-banner new user', () => {
 
     it('should set consent cookie', async () => {
       const cookies = await page.cookies()
-      expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'cookies_policy' })]))
+      expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'dm_cookies_policy' })]))
       expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ value: '{"analytics":true}' })]))
     })
 
@@ -121,7 +121,7 @@ describe('cookie-banner new user', () => {
 
   describe('cookie-banner rejecting analytics', () => {
     beforeEach(async () => {
-      await page.deleteCookie({ name: 'cookies_policy' })
+      await page.deleteCookie({ name: 'dm_cookies_policy' })
       await page.deleteCookie({ name: '_gid' })
       await page.deleteCookie({ name: '_ga' })
 
@@ -136,7 +136,7 @@ describe('cookie-banner new user', () => {
 
     it('should set consent cookie', async () => {
       const cookies = await page.cookies()
-      expect(cookies[0].name).toEqual('cookies_policy')
+      expect(cookies[0].name).toEqual('dm_cookies_policy')
       expect(cookies[0].value).toEqual('{"analytics":false}')
     })
 

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.yaml
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.yaml
@@ -8,6 +8,8 @@ examples:
   - name: default
     data:
       serviceName: Digital Marketplace
+      cookieInfoUrl: '/cookies'
+      cookieSettingsUrl: '/user/cookie-settings'
   - name: with custom service name
     data:
       serviceName: Digital Marketplace Admin

--- a/src/digitalmarketplace/components/cookie-banner/template.njk
+++ b/src/digitalmarketplace/components/cookie-banner/template.njk
@@ -1,5 +1,7 @@
 {% set componentID = params.id if params.id else 'dm-cookie-banner' %}
 {% set serviceName = params.serviceName if params.serviceName else 'Digital Marketplace' %}
+{% set cookieInfoUrl = params.cookieInfoUrl if params.cookieInfoUrl else '/cookies' %}
+{% set cookieSettingsUrl = params.cookieSettingsUrl if params.cookieSettingsUrl else '/users/cookie-settings' %}
 
 <div id="{{ componentID }}" class="dm-cookie-banner govuk-width-container" data-module="dm-cookie-banner" role="region" aria-describedby="dm-cookie-banner__heading">
   <div class="dm-cookie-banner__wrapper">
@@ -16,13 +18,13 @@
       <button class="govuk-button dm-cookie-banner__button dm-cookie-banner__button--reject" type="submit" data-accept-cookies="false" aria-describedby="dm-cookie-banner__heading">
         No<span class="govuk-visually-hidden">, {{ serviceName }} cannot store analytics cookies on your device</span>
       </button>
-      <a class="govuk-link dm-cookie-banner__link" href="/cookies">How {{ serviceName }} uses cookies</a>
+      <a class="govuk-link dm-cookie-banner__link" href="{{ cookieInfoUrl }}">How {{ serviceName }} uses cookies</a>
     </div>
   </div>
 
   <div class="dm-cookie-banner__confirmation" tabindex="-1">
     <p class="dm-cookie-banner__confirmation-message govuk-body">
-      You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.
+      You can <a class="govuk-link" href="{{ cookieSettingsUrl }}">change your cookie settings</a> at any time.
     </p>
     <button class="dm-cookie-banner__hide-button govuk-link" data-hide-cookie-banner="true" role="link">Hide</button>
   </div>

--- a/src/digitalmarketplace/helpers/cookie/cookie-functions.js
+++ b/src/digitalmarketplace/helpers/cookie/cookie-functions.js
@@ -55,7 +55,7 @@ function Cookie (name, value, options) {
 }
 
 export function getConsentCookie () {
-  var consentCookie = getCookie('cookies_policy')
+  var consentCookie = getCookie('dm_cookies_policy')
   var consentCookieObj
 
   if (consentCookie) {
@@ -99,7 +99,7 @@ export function setConsentCookie (options) {
     }
   }
 
-  setCookie('cookies_policy', JSON.stringify(cookieConsent), { days: 365 })
+  setCookie('dm_cookies_policy', JSON.stringify(cookieConsent), { days: 365 })
 }
 
 function checkConsentCookieCategory (cookieName, cookieCategory) {
@@ -123,7 +123,7 @@ function checkConsentCookieCategory (cookieName, cookieCategory) {
 
 function checkConsentCookie (cookieName, cookieValue) {
   // If we're setting the consent cookie OR deleting a cookie, allow by default
-  if (cookieName === 'cookies_policy' || (cookieValue === null || cookieValue === false)) {
+  if (cookieName === 'dm_cookies_policy' || (cookieValue === null || cookieValue === false)) {
     return true
   }
 


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

Small Cookie Banner fixes:
- We should use `dm_cookies_policy` to be in line with our other custom cookies
- There are two cookie URLs: one for the Cookie Settings page (`/user/cookies` - User FE) and one for detailed cookie info (`/cookies` - Buyer FE). I've amended the template to make this clearer.
- The cookie banner should not be displayed on the Cookie Settings page, as then there would be two forms on the page, which could be confusing. It's fine to have the banner on the Cookie Info page however, where there's no form. However, this check will be done by the Cookie Settings page  itself, not the banner code. 