### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,24 @@
 
 ## Unreleased
 
+See Changelog Examples at the bottom of this page.
+
+## 0.6.0
+
 🆕 New features:
 
 - New component: Cookie settings page javascript
 
   - Allows a user to set their analytics cookie preferences
 
+  ([PR #60](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/60))
+
 🔧 Fixes:
 
 - Use dm_cookies_policy to be in line with our other custom cookies
 - Use template parameters for Cookie Settings URL and Cookie Info URL
 - Banner should not be displayed on the Cookie Settings page
+- Prefix custom CSS classes with 'dm-'
 
   ([PR #62](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/62))
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
🆕 New features:

- New component: Cookie settings page javascript

  - Allows a user to set their analytics cookie preferences

  ([PR #60](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/60))

🔧 Fixes:

- Use dm_cookies_policy to be in line with our other custom cookies
- Use template parameters for Cookie Settings URL and Cookie Info URL
- Banner should not be displayed on the Cookie Settings page
- Prefix custom CSS classes with 'dm-'

  ([PR #62](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/62))
