### PR TITLE
Parse consent cookie value as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-See Changelog Examples at the bottom of this page.
+🔧 Fixes:
+
+- Fix pre-filled values on the Cookie Settings form, by parsing dm_cookies_policy as a JSON object.
+
+  ([PR #67](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/67))
 
 ## 0.6.0
 

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -1,5 +1,5 @@
 // Javascript code to support the Cookie Settings page
-import { getCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
+import { getConsentCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
 import InitialiseAnalytics from '../analytics/init'
 
 export function CookieSettings ($module) {
@@ -18,7 +18,7 @@ CookieSettings.prototype.init = function () {
 }
 
 CookieSettings.prototype.setInitialFormValues = function () {
-  var currentConsentCookie = getCookie('dm_cookies_policy')
+  var currentConsentCookie = getConsentCookie()
 
   if (!currentConsentCookie) {
     // Don't populate the form

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
@@ -49,7 +49,7 @@ beforeEach(() => {
 
 afterEach(() => {
   CookieHelpers.setConsentCookie.mockClear()
-  CookieHelpers.getCookie.mockClear()
+  CookieHelpers.getConsentCookie.mockClear()
   InitialiseAnalytics.mockClear()
 })
 
@@ -86,7 +86,7 @@ describe('Cookie settings', () => {
 
     describe('with existing analytics', () => {
       beforeEach(async () => {
-        CookieHelpers.getCookie.mockImplementation(() => {
+        CookieHelpers.getConsentCookie.mockImplementation(() => {
           return { dm_cookies_policy: { analytics: true } }
         })
       })


### PR DESCRIPTION
https://trello.com/c/0PYrZ8Yy/323-cookie-settings-form-defaults-to-no-even-if-preference-set-to-yes

The Cookie Settings form was always defaulting to 'No', as the existing consent cookie value was not being parsed correctly (the test for it was returning a mocked response that was already a JSON object).

There is already a helper function to solve this very problem, `getConsentCookie`, which we weren't using 🤦‍♀ 