### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+See changelog examples at the bottom of this page.
+
+## 0.6.1
+
 🔧 Fixes:
 
 - Fix pre-filled values on the Cookie Settings form, by parsing dm_cookies_policy as a JSON object.

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
🔧 Fixes:

- Fix pre-filled values on the Cookie Settings form, by parsing dm_cookies_policy as a JSON object.

  ([PR #67](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/67))