### PR TITLE
Fix tracking ID fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-See changelog examples at the bottom of this page.
+🔧 Fixes:
+
+- Fix incorrect Google Analytics tracking ID.
+  ([PR #70](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/70))
 
 ## 0.6.1
 

--- a/src/digitalmarketplace/components/analytics/init.js
+++ b/src/digitalmarketplace/components/analytics/init.js
@@ -3,7 +3,7 @@ import * as PageAnalytics from './analytics'
 window.DMGOVUKFrontend = window.DMGOVUKFrontend || {}
 
 // TODO: Remove hard coded tracking ID to make this more generic and useful to others
-const trackingId = 'UA-26179049-1'
+const trackingId = 'UA-49258698-1'
 
 window[`ga-disable-${trackingId}`] = true
 

--- a/src/digitalmarketplace/components/analytics/init.test.js
+++ b/src/digitalmarketplace/components/analytics/init.test.js
@@ -21,7 +21,7 @@ beforeAll(() => {
 
 describe('InitialiseAnalytics component', () => {
   it('Google Analytics is disabled by default', async () => {
-    expect(window['ga-disable-UA-26179049-1']).toBe(true)
+    expect(window['ga-disable-UA-49258698-1']).toBe(true)
   })
 
   describe('If initAnalytics has already been called', () => {
@@ -59,7 +59,7 @@ describe('InitialiseAnalytics component', () => {
     })
 
     it('Google Analytics will not be disabled', () => {
-      expect(window['ga-disable-UA-26179049-1']).toBe(false)
+      expect(window['ga-disable-UA-49258698-1']).toBe(false)
     })
 
     it('the Google Analytics libraries will have been loaded', () => {


### PR DESCRIPTION
Quick fix: the GOV.UK tracking ID was being used instead of the Digital Marketplace ID.