### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+See below for example changelog entries.
+
+## 0.6.2
+
 🔧 Fixes:
 
 - Fix incorrect Google Analytics tracking ID.

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
🔧 Fixes:

- Fix incorrect Google Analytics tracking ID.
  ([PR #70](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/70))
