### PR TITLE
Fix analytics cookie domain

### DIFF
--- a/src/digitalmarketplace/components/analytics/init.js
+++ b/src/digitalmarketplace/components/analytics/init.js
@@ -12,8 +12,7 @@ function InitialiseAnalytics () {
   if (!('analytics' in window.DMGOVUKFrontend)) {
     window[`ga-disable-${trackingId}`] = false
 
-    // TODO: Check if we still need this hack for the domain
-    const cookieDomain = (document.domain === 'www.digitalmarketplace.service.gov.uk') ? '.digitalmarketplace.service.gov.uk' : document.domain
+    const cookieDomain = (document.domain === 'www.digitalmarketplace.service.gov.uk') ? '.www.digitalmarketplace.service.gov.uk' : document.domain
 
     // Load Analytics libraries
     PageAnalytics.LoadGoogleAnalytics()


### PR DESCRIPTION
On production our Google Analytics cookies have been attached to `digitalmarketplace.service.gov.uk`, rather than `www.digitalmarketplace.service.gov.uk` where all our other cookies are attached.

This commit changes the cookie domain "hack" to make sure that they align with our other cookies (similar to how its done in https://github.com/alphagov/static/blob/master/doc/analytics.md).