### PR TITLE
Initialise Analytics if consent cookie is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-See below for example changelog entries.
+🔧 Fixes:
+
+- Initialise Analytics if consent cookie is present.
 
 ## 0.6.2
 

--- a/src/digitalmarketplace/all.js
+++ b/src/digitalmarketplace/all.js
@@ -2,6 +2,7 @@ import CookieBanner from './components/cookie-banner/cookie-banner'
 import CookieSettings from './components/cookie-settings/cookie-settings'
 import * as Analytics from './components/analytics/analytics'
 import initAnalytics from './components/analytics/init'
+import { getConsentCookie } from './helpers/cookie/cookie-functions'
 
 function initAll (options) {
   const $cookieBanner = document.querySelector('[data-module="dm-cookie-banner"]')
@@ -11,6 +12,10 @@ function initAll (options) {
   const $cookieSettingsPage = document.querySelector('[data-module="dm-cookie-settings"]')
   if ($cookieSettingsPage) {
     new CookieSettings($cookieSettingsPage).init()
+  }
+  const currentConsentCookie = getConsentCookie()
+  if (currentConsentCookie && currentConsentCookie.analytics) {
+    initAnalytics()
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/feRizfhu/326-analytics-tracking-id-fix

As per Notify's initialisation code: https://github.com/alphagov/notifications-admin/blob/master/app/assets/javascripts/main.js#L6
