### PR TITLE
Remove tracker name from Google Analytics create command event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ## Unreleased
+
 See below for Changelog examples.
+
+🔧 Fixes:
+
+- Remove Google Analytics tracker name.
 
 ## 0.6.3
 

--- a/src/digitalmarketplace/components/analytics/analytics.js
+++ b/src/digitalmarketplace/components/analytics/analytics.js
@@ -1,7 +1,7 @@
 // Stripped-down wrapper for Google Analytics, based on:
 // https://github.com/alphagov/static/blob/master/doc/analytics.md
 export function SetupAnalytics (config) {
-  window.ga('create', config.trackingId, config.cookieDomain, config.name, { cookieExpires: config.expires * 24 * 60 * 60 })
+  window.ga('create', config.trackingId, config.cookieDomain, { cookieExpires: config.expires * 24 * 60 * 60 })
 
   window.ga('set', 'anonymizeIp', config.anonymizeIp)
   window.ga('set', 'displayFeaturesTask', config.displayFeaturesTask)

--- a/src/digitalmarketplace/components/analytics/analytics.test.js
+++ b/src/digitalmarketplace/components/analytics/analytics.test.js
@@ -9,7 +9,6 @@ const defaultConfig = {
   anonymizeIp: true,
   displayFeaturesTask: null,
   transport: 'beacon',
-  name: 'DMGOVUKFrontend',
   expires: 365
 }
 
@@ -32,7 +31,7 @@ afterEach(() => {
 describe('analytics component', () => {
   it('init creates script element', async () => {
     expect(window.ga.mock.calls).toEqual([
-      ['create', 'UA-12345', 'www.digitalmarketplace.service.gov.uk', 'DMGOVUKFrontend', { cookieExpires: 31536000 }],
+      ['create', 'UA-12345', 'www.digitalmarketplace.service.gov.uk', { cookieExpires: 31536000 }],
       ['set', 'anonymizeIp', true],
       ['set', 'displayFeaturesTask', null],
       ['set', 'transport', 'beacon']

--- a/src/digitalmarketplace/components/analytics/init.js
+++ b/src/digitalmarketplace/components/analytics/init.js
@@ -26,7 +26,6 @@ function InitialiseAnalytics () {
       anonymizeIp: true,
       displayFeaturesTask: null,
       transport: 'beacon',
-      name: 'DMGOVUKFrontend.analytics',
       expires: 365
     })
 

--- a/src/digitalmarketplace/components/analytics/init.test.js
+++ b/src/digitalmarketplace/components/analytics/init.test.js
@@ -75,7 +75,6 @@ describe('InitialiseAnalytics component', () => {
           anonymizeIp: true,
           displayFeaturesTask: null,
           transport: 'beacon',
-          name: 'DMGOVUKFrontend.analytics',
           expires: 365
         })
       )


### PR DESCRIPTION
Looking at the Google Analytics documentation[[1], [2]] and examples from Notify[[3]] and our previous code[[4]] I don't think this is needed.

[1]: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#name
[2]: https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers
[3]: https://github.com/alphagov/notifications-admin/blob/master/app/assets/javascripts/analytics/analytics.js
[4]: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/javascripts/analytics/_register.js