### PR TITLE
Fix "frameword" typo in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See below for Changelog examples.
 
+🔧 Fixes:
+
+- Fix typo in footer. ([PR #79](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/79))
+
 ### 0.6.4
 
 🔧 Fixes:

--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -44,7 +44,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
               <ul class=\\"govuk-footer__list \\">
                     <li class=\\"govuk-footer__list-item\\">
                       <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/g-cloud-suppliers-guide\\">
-                        Applying to sell on the G-Cloud frameword
+                        Applying to sell on the G-Cloud framework
                       </a>
                     </li>
                     <li class=\\"govuk-footer__list-item\\">

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -35,7 +35,7 @@
       items: [
         {
           href: 'https://www.gov.uk/guidance/g-cloud-suppliers-guide',
-          text: 'Applying to sell on the G-Cloud frameword'
+          text: 'Applying to sell on the G-Cloud framework'
         },
         {
           href: 'https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide',


### PR DESCRIPTION
The footer on the Digital Marketplace is showing the link "Applying to sell on the G-Cloud *frameword*"
I assume this is a typo - this PR fixes it