### PR TITLE
Cross domain tracking code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-See below for Changelog examples.
+🆕 New features:
+
+- Adding gov.uk cross-domain tracking to Digital Marketplace analytics, based on the old [Frontend Toolkit analytics code](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/javascripts/analytics/_register.js#L16).
+    - Includes function calls to strip personal data from both DMP analytics events and cross domain tracker events.
 
 ## 0.7.0
 

--- a/src/digitalmarketplace/components/analytics/analytics.js
+++ b/src/digitalmarketplace/components/analytics/analytics.js
@@ -22,7 +22,7 @@ export function LoadGoogleAnalytics () { /* eslint-disable */
 
 export function TrackPageview (path, title, options) {
   const page = (window.location.pathname + window.location.search)
-  window.ga('send', 'pageview', page)
+  window.ga('send', 'pageview', stripPII(page))
 }
 
 // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
@@ -43,7 +43,7 @@ export function TrackEvent (category, action, options) {
     Object.assign(evt, options)
   }
 
-  window.ga('send', 'event', evt)
+  window.ga('send', 'event', stripPII(evt))
 }
 
 export function AddLinkedTrackerDomain (trackingId, name, domains) {

--- a/src/digitalmarketplace/components/analytics/analytics.js
+++ b/src/digitalmarketplace/components/analytics/analytics.js
@@ -1,3 +1,5 @@
+import stripPII from './pii'
+
 // Stripped-down wrapper for Google Analytics, based on:
 // https://github.com/alphagov/static/blob/master/doc/analytics.md
 export function SetupAnalytics (config) {
@@ -44,3 +46,18 @@ export function TrackEvent (category, action, options) {
   window.ga('send', 'event', evt)
 }
 
+export function AddLinkedTrackerDomain (trackingId, name, domains) {
+  window.ga('create', trackingId, 'auto', { name: name })
+
+  // Load the plugin.
+  window.ga('require', 'linker')
+  window.ga(name + '.require', 'linker')
+
+  // Define which domains to autoLink.
+  window.ga('linker:autoLink', domains)
+  window.ga(name + '.linker:autoLink', domains)
+
+  window.ga(name + '.set', 'anonymizeIp', true)
+  window.ga(name + '.set', 'location', stripPII(window.location.href))
+  window.ga(name + '.send', 'pageview')
+}

--- a/src/digitalmarketplace/components/analytics/init.js
+++ b/src/digitalmarketplace/components/analytics/init.js
@@ -2,8 +2,9 @@ import * as PageAnalytics from './analytics'
 
 window.DMGOVUKFrontend = window.DMGOVUKFrontend || {}
 
-// TODO: Remove hard coded tracking ID to make this more generic and useful to others
+// TODO: Remove hard coded tracking IDs to make this more generic and useful to others
 const trackingId = 'UA-49258698-1'
+const linkedTrackingId = 'UA-145652997-1'
 
 window[`ga-disable-${trackingId}`] = true
 
@@ -28,6 +29,9 @@ function InitialiseAnalytics () {
       transport: 'beacon',
       expires: 365
     })
+
+    // Add cross-domain tracking for www.gov.uk domain
+    PageAnalytics.AddLinkedTrackerDomain(linkedTrackingId, 'govuk_shared', ['www.gov.uk'])
 
     // Track initial pageview
     PageAnalytics.TrackPageview()

--- a/src/digitalmarketplace/components/analytics/init.test.js
+++ b/src/digitalmarketplace/components/analytics/init.test.js
@@ -46,6 +46,10 @@ describe('InitialiseAnalytics component', () => {
       expect(PageAnalytics.SetupAnalytics).not.toHaveBeenCalled()
     })
 
+    it('the linked tracker domain will not have been fired', () => {
+      expect(PageAnalytics.AddLinkedTrackerDomain).not.toHaveBeenCalled()
+    })
+
     it('the initial trackPageview will not have been fired', () => {
       expect(PageAnalytics.TrackPageview).not.toHaveBeenCalled()
     })
@@ -78,6 +82,10 @@ describe('InitialiseAnalytics component', () => {
           expires: 365
         })
       )
+    })
+
+    it('adds the linked tracker domain', () => {
+      expect(PageAnalytics.AddLinkedTrackerDomain).toHaveBeenCalled()
     })
 
     it('fires an initial trackPageview', () => {

--- a/src/digitalmarketplace/components/analytics/pii.js
+++ b/src/digitalmarketplace/components/analytics/pii.js
@@ -1,0 +1,51 @@
+
+// Based on https://github.com/alphagov/static/pull/1863
+const EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+
+// Not quite sure what this is doing,
+// see https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/javascripts/analytics/_govukAnalytics.js#L19
+const PIISafe = function (value) {
+  this.value = value
+}
+
+function stripPII (value) {
+  if (typeof value === 'string') {
+    return stripPIIFromString(value)
+  } else if (Object.prototype.toString.call(value) === '[object Array]' || Object.prototype.toString.call(value) === '[object Arguments]') {
+    return stripPIIFromArray(value)
+  } else if (typeof value === 'object') {
+    return stripPIIFromObject(value)
+  } else {
+    return value
+  }
+}
+
+function stripPIIFromString (string) {
+  return string.replace(EMAIL_PATTERN, '[email]')
+}
+
+function stripPIIFromObject (object) {
+  if (object) {
+    if (object instanceof PIISafe) {
+      return object.value
+    } else {
+      for (var property in object) {
+        var value = object[property]
+
+        object[property] = stripPII(value)
+      }
+      return object
+    }
+  }
+}
+
+function stripPIIFromArray (array) {
+  for (var i = 0, l = array.length; i < l; i++) {
+    var elem = array[i]
+
+    array[i] = stripPII(elem)
+  }
+  return array
+}
+
+export default stripPII

--- a/src/digitalmarketplace/components/analytics/pii.test.js
+++ b/src/digitalmarketplace/components/analytics/pii.test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import stripPII from './pii'
+
+beforeAll(() => {
+  // add the script GA looks for in the document
+  document.body.appendChild(document.createElement('script'))
+})
+
+beforeEach(() => {
+  // Set up mock
+  window.ga = jest.fn()
+})
+
+afterEach(() => {
+  window.ga.mockClear()
+})
+
+describe('stripPII', () => {
+  it('strips email addresses from strings', () => {
+    const results = stripPII('this is an@email.com address')
+    expect(results).toEqual('this is [email] address')
+  })
+
+  it('strips email addresses from objects', () => {
+    const obj = {
+      email: 'this is an@email.com address',
+      another: 'key'
+    }
+
+    const strippedObj = {
+      email: 'this is [email] address',
+      another: 'key'
+    }
+
+    const results = stripPII(obj)
+    expect(results).toEqual(strippedObj)
+  })
+
+  it('strips email addresses from arrays', () => {
+    const arr = [
+      'this is an@email.com address',
+      'this is another item'
+    ]
+
+    const strippedArr = [
+      'this is [email] address',
+      'this is another item'
+    ]
+
+    const results = stripPII(arr)
+    expect(results).toEqual(strippedArr)
+  })
+})

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.test.js
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.test.js
@@ -80,6 +80,7 @@ describe('cookie-banner new user', () => {
       await page.deleteCookie({ name: 'dm_cookies_policy' })
       await page.deleteCookie({ name: '_gid' })
       await page.deleteCookie({ name: '_ga' })
+      await page.deleteCookie({ name: '_gat_govuk_shared' })
 
       await goToAndGetComponent('cookie-banner')
       await page.click('.dm-cookie-banner__button--accept')
@@ -96,14 +97,15 @@ describe('cookie-banner new user', () => {
       expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ value: '{"analytics":true}' })]))
     })
 
-    // Flaky test - only 2 out of 3 cookies are set reliability before the assertion
-    it.skip('should have analytics cookies set', async () => {
+    // Flaky test - only 3 out of 4 cookies are set reliability before the assertion
+    it('should have analytics cookies set', async () => {
       const cookies = await page.cookies()
       // Make sure we wait until the page has loaded the Analytics code
       await page.evaluate(() => window.GoogleAnalyticsObject)
       expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ name: '_gid' })]))
       expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ name: '_ga' })]))
-      expect(cookies.length).toEqual(3) // 2 GA cookies plus consent cookie
+      expect(cookies).toEqual(expect.arrayContaining([expect.objectContaining({ name: '_gat_govuk_shared' })]))
+      expect(cookies.length).toEqual(4) // 3 GA cookies plus consent cookie
     })
 
     it('should have analytics enabled', async () => {
@@ -124,6 +126,7 @@ describe('cookie-banner new user', () => {
       await page.deleteCookie({ name: 'dm_cookies_policy' })
       await page.deleteCookie({ name: '_gid' })
       await page.deleteCookie({ name: '_ga' })
+      await page.deleteCookie({ name: '_gat_govuk_shared' })
 
       await goToAndGetComponent('cookie-banner')
       await page.click('.dm-cookie-banner__button--reject')


### PR DESCRIPTION
https://trello.com/c/hRRSka2u/5-re-enable-cross-domain-tracking-3

Copies across cross-domain tracking code (and tests!) from the old Frontend Toolkit, with some minor adjustments to fit the new linter/testing style.

I've updated the flaky test in `cookie-banner.test.js` with the expected `gat_govuk_shared` cookie, and removed the `skip` - let's see if Travis likes it.