### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+See below for Changelog examples.
+
+## 0.8.0
 
 🆕 New features:
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
https://trello.com/c/hRRSka2u/5-re-enable-cross-domain-tracking-3

## 0.8.0

🆕 New features:

- Adding gov.uk cross-domain tracking to Digital Marketplace analytics, based on the old [Frontend Toolkit analytics code](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/javascripts/analytics/_register.js#L16).
    - Includes function calls to strip personal data from both DMP analytics events and cross domain tracker events.
