### PR TITLE
Fix banner and alert failing axe region rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See below for Changelog examples.
   - Representative usage examples for the banner component [PR #114](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/114).
 
 🔧 Fixes:
+  - Add ARIA roles and labels to alert and banner components [PR #113](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/113)
+  - Adjust tabindex attribute on alert and banner components [PR #113](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/113)
   - Fix mismatched tags in the banner component [PR #114](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/114).
   - Ensure links are readable in the banner component [PR #114](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/114).
 

--- a/src/digitalmarketplace/components/alert/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/alert/__snapshots__/template.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`alert renders an alert component with error message 1`] = `
-"<html><head></head><body><div data-module=\\"dm-alert\\" class=\\"dm-alert dm-alert--error dm-alert-test-class\\" dm-alert-test-key-1=\\"dm-alert-test-value-1\\" dm-alert-test-key-2=\\"dm-alert-test-value-2\\" tabindex=\\"0\\">
+"<html><head></head><body><div data-module=\\"dm-alert\\" role=\\"alert\\" aria-label=\\"An action has been completed that lead to an error alert.\\" class=\\"dm-alert dm-alert--error dm-alert-test-class\\" dm-alert-test-key-1=\\"dm-alert-test-value-1\\" dm-alert-test-key-2=\\"dm-alert-test-value-2\\" tabindex=\\"-1\\">
     <h2 class=\\"dm-alert__title dm-alert__title--large\\">
         An action has been <span style=\\"color: red\\">completed</span> that lead to an error alert.
     </h2>
@@ -13,7 +13,7 @@ exports[`alert renders an alert component with error message 1`] = `
 `;
 
 exports[`alert renders an alert component with the optional headingLevel param of 1 1`] = `
-"<html><head></head><body><div data-module=\\"dm-alert\\" class=\\"dm-alert dm-alert--notice\\" tabindex=\\"0\\">
+"<html><head></head><body><div data-module=\\"dm-alert\\" role=\\"alert\\" aria-label=\\"A successful action has been completed.\\" class=\\"dm-alert dm-alert--notice\\" tabindex=\\"-1\\">
     <h1 class=\\"dm-alert__title\\">
         A successful action has been completed.
     </h1>
@@ -22,7 +22,7 @@ exports[`alert renders an alert component with the optional headingLevel param o
 `;
 
 exports[`alert renders an alert component with the title text 1`] = `
-"<html><head></head><body><div data-module=\\"dm-alert\\" class=\\"dm-alert dm-alert--success\\" tabindex=\\"0\\">
+"<html><head></head><body><div data-module=\\"dm-alert\\" role=\\"alert\\" aria-label=\\"A successful action has been completed.\\" class=\\"dm-alert dm-alert--success\\" tabindex=\\"-1\\">
     <h2 class=\\"dm-alert__title dm-alert__title--large\\">
         A successful action has been completed.
     </h2>

--- a/src/digitalmarketplace/components/alert/template.njk
+++ b/src/digitalmarketplace/components/alert/template.njk
@@ -1,8 +1,10 @@
 <div
     data-module="dm-alert"
-    class="dm-alert dm-alert--{{ params.type }}{%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for key, value in params.attributes %} {{key}}="{{value}}"{% endfor %}
-    tabindex="0"
+    role="alert"
+    aria-label="{{ params.titleHtml|striptags if params.titleHtml else params.titleText }}"
+    class="dm-alert{%- if params.type %} dm-alert--{{ params.type }}{% endif %}{%- if params.classes %} {{ params.classes }}{% endif %}"
+    {% for key, value in params.attributes %} {{key}}="{{value}}"{% endfor %}
+    tabindex="-1"
 >
     <h{% if params.headingLevel %}{{ params.headingLevel }}{% else %}2{% endif %}
         class="dm-alert__title{% if params.html or params.text %} dm-alert__title--large{% endif %}"

--- a/src/digitalmarketplace/components/banner/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/banner/__snapshots__/template.test.js.snap
@@ -1,11 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`banner renders a banner component with the title text 1`] = `
-"<html><head></head><body><section data-module=\\"dm-banner\\" class=\\"dm-banner dm-banner--\\" tabindex=\\"0\\">
+"<html><head></head><body><section data-module=\\"dm-banner\\" role=\\"region\\" aria-label=\\"This is the title of the banner component.\\" class=\\"dm-banner\\">
     <h2 class=\\"dm-banner__title dm-banner__title--large\\">
         This is the title of the banner component.
-    </h2>
-        <div class=\\"dm-banner__body\\">
+    </h2>        <div class=\\"dm-banner__body\\">
             This is the text below the title.
         </div>
 </section>
@@ -13,10 +12,9 @@ exports[`banner renders a banner component with the title text 1`] = `
 `;
 
 exports[`banner renders an banner component with the optional headingLevel param of 1 1`] = `
-"<html><head></head><body><section data-module=\\"dm-banner\\" class=\\"dm-banner dm-banner--\\" tabindex=\\"0\\">
+"<html><head></head><body><section data-module=\\"dm-banner\\" role=\\"region\\" aria-label=\\"Banner with optional headingLevel param.\\" class=\\"dm-banner\\">
     <h1 class=\\"dm-banner__title\\">
         Banner with optional headingLevel param.
-    </h1>
-</section>
+    </h1></section>
 </body></html>"
 `;

--- a/src/digitalmarketplace/components/banner/template.njk
+++ b/src/digitalmarketplace/components/banner/template.njk
@@ -1,15 +1,16 @@
 <section
     data-module="dm-banner"
-    class="dm-banner dm-banner--{{ params.type }}{%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for key, value in params.attributes %} {{key}}="{{value}}"{% endfor %}
-    tabindex="0"
+    role="region"
+    aria-label="{{ params.title }}"
+    class="dm-banner{%- if params.type %} dm-banner--{{ params.type }}{% endif %}{%- if params.classes %} {{ params.classes }}{% endif %}"
+    {%- for key, value in params.attributes %} {{key}}="{{value}}" {%- endfor %}
 >
     <h{% if params.headingLevel %}{{ params.headingLevel }}{% else %}2{% endif %}
         class="dm-banner__title{% if params.html or params.text %} dm-banner__title--large{% endif %}"
     >
         {{ params.title }}
     </h{% if params.headingLevel %}{{ params.headingLevel }}{% else %}2{% endif %}>
-    {% if params.html or params.text %}
+    {%- if params.html or params.text %}
         <div class="dm-banner__body">
             {{ params.html|safe if params.html else params.text }}
         </div>


### PR DESCRIPTION
https://trello.com/c/FR1sGM3j/22-2-fix-axe-errors-in-digitalmarketplace-govuk-frontend

The Alert and Banner components fail [this rule](https://dequeuniversity.com/rules/axe/3.5/region)

Partly, this is because when the test templates are rendered, cheerio is wrapping them with some boilerplate, but not a `<main>` or other recognised ARIA landmark.

However, this gives us the chance to improve the component accessibility and pass the tests even with the poor wrap.

### Alert
* Follow GOV.UK [Error Summary](https://design-system.service.gov.uk/components/error-summary/) and set `role="alert"` and `tabindex="-1"`. Set the `aria-label` to be the same as the title. Future improvement may be to generate an ID for the heading and use `aria-labelledby` instead.

### Banner
* Since banners are not live-regions, we can use `role=region` and set `aria-label` to the title again.
* Remove `tabindex="0"` - tabbable items should be interactive, and since banners appear in content, they'll be navigable in HTML order.