### PR TITLE
Add representative banner examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 See below for Changelog examples.
 
+## Unreleased
+
+🆕 New features:
+  - Representative usage examples for the banner component [PR #114](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/114).
+
+🔧 Fixes:
+  - Fix mismatched tags in the banner component [PR #114](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/114).
+  - Ensure links are readable in the banner component [PR #114](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/114).
+
 ## 0.8.1
 
 🔧 Fixes:

--- a/src/digitalmarketplace/components/banner/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/banner/__snapshots__/template.test.js.snap
@@ -8,7 +8,8 @@ exports[`banner renders a banner component with the title text 1`] = `
         <div class=\\"dm-banner__body\\">
             This is the text below the title.
         </div>
-</section></body></html>"
+</section>
+</body></html>"
 `;
 
 exports[`banner renders an banner component with the optional headingLevel param of 1 1`] = `
@@ -16,5 +17,6 @@ exports[`banner renders an banner component with the optional headingLevel param
     <h1 class=\\"dm-banner__title\\">
         Banner with optional headingLevel param.
     </h1>
-</section></body></html>"
+</section>
+</body></html>"
 `;

--- a/src/digitalmarketplace/components/banner/_banner.scss
+++ b/src/digitalmarketplace/components/banner/_banner.scss
@@ -23,4 +23,19 @@
         @include govuk-responsive-padding(4,"top");
         @include govuk-responsive-padding(0,"bottom");
     }
+
+    .dm-banner__body a {
+        // Override default link styling
+        &:link,
+        &:visited,
+        &:hover,
+        &:active {
+            color: govuk-colour("white");
+        }
+
+        // TODO: Add this in when we move to govuk-frontend@3
+        // &:focus {
+        //     @include govuk-focused-text;
+        // }
+    }
 }

--- a/src/digitalmarketplace/components/banner/banner.yaml
+++ b/src/digitalmarketplace/components/banner/banner.yaml
@@ -40,3 +40,16 @@ examples:
       text: This should not show up.
       classes: dm-banner-test-class
       attributes: {"dm-banner-test-key-1": "dm-banner-test-value-1", "dm-banner-test-key-2": "dm-banner-test-value-2"}
+  - name: for an expired G-Cloud search
+    data:
+      title: The G-Cloud 10 services you found have expired
+      html: |
+        If you did not award a contract by Tuesday 2 July 2019, you need to
+        <a class="govuk-link" href="#">start a new search for G-Cloud 11 services</a>.
+        If you did award a contract, please tell us the outcome.
+  - name: for a withdrawn DOS opportunity
+    data:
+      title: This service was removed on Friday 1 November 2019
+      html: |
+        If you don’t know why this service was removed or you want to reinstate it, contact
+        <a class="govuk-link" href="mailto:#">cloud_digital@crowncommercial.gov.uk</a>.

--- a/src/digitalmarketplace/components/banner/template.njk
+++ b/src/digitalmarketplace/components/banner/template.njk
@@ -14,4 +14,4 @@
             {{ params.html|safe if params.html else params.text }}
         </div>
     {% endif %}
-</div>
+</section>


### PR DESCRIPTION
While having a conversation with @domoscargin I realised that our banner examples could be more representative of how they are to be used on the site.

While doing *that*, I discovered that the link text was wrong :laughing:

### Screenshots

![Screenshot of banners for an expired G-Cloud search and a withdrawn DOS opportunity](https://user-images.githubusercontent.com/503614/80703377-8fe6e980-8ada-11ea-9fb1-d0d644414a35.png)
