### PR TITLE
add and remove inline error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 See below for Changelog examples.
 
+## Unreleased
+
+🔧 Fixes:
+  - Javascript to support error message on cookie settings page [PR #124](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/124)
+
 ## 0.9.0
 
 🆕 New features:

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -99,7 +99,7 @@ CookieSettings.prototype.showErrorMessage = function () {
     errorMessage.style.display = 'block'
     document.body.scrollTop = document.documentElement.scrollTop = 0
   }
-  showInlineErrorMessage()
+  this.showInlineErrorMessage()
 }
 
 CookieSettings.prototype.hideErrorMessage = function () {
@@ -107,7 +107,7 @@ CookieSettings.prototype.hideErrorMessage = function () {
   if (errorMessage !== null) {
     errorMessage.style.display = 'none'
   }
-  hideInlineErrorMessage()
+  this.hideInlineErrorMessage()
 }
 
 CookieSettings.prototype.hideWarningMessage = function () {
@@ -117,7 +117,7 @@ CookieSettings.prototype.hideWarningMessage = function () {
   }
 }
 
-function hideInlineErrorMessage () {
+CookieSettings.prototype.hideInlineErrorMessage = function () {
   var inlineErrorMessage = document.querySelector('#dm-cookie-settings-error-inline')
   if (inlineErrorMessage !== null) {
     inlineErrorMessage.style.display = 'none'
@@ -127,7 +127,7 @@ function hideInlineErrorMessage () {
   inlineErrorHighlight && inlineErrorHighlight.classList.remove('govuk-form-group--error')
 }
 
-function showInlineErrorMessage () {
+CookieSettings.prototype.showInlineErrorMessage = function () {
   var firstFormGroup = document.querySelector('.govuk-form-group')
   firstFormGroup && firstFormGroup.classList.add('govuk-form-group--error')
 
@@ -136,7 +136,7 @@ function showInlineErrorMessage () {
   inlineErrorSpan.className = 'govuk-error-message'
   inlineErrorSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Please select \'Yes\' or \'No\''
 
-  var siblingElement = document.getElementsByClassName('govuk-radios govuk-radios--inline')[0]
+  var siblingElement = document.querySelector('govuk-radios govuk-radios--inline')
   var parentElement = siblingElement.parentElement
   parentElement.insertBefore(inlineErrorSpan, siblingElement)
 }

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -128,7 +128,7 @@ CookieSettings.prototype.hideErrorMessage = function () {
 }
 
 CookieSettings.prototype.showErrorMessage = function () {
-  var formGroup = document.querySelector('#dm-cookie-settings, .govuk-form-group')
+  var formGroup = document.querySelector('#dm-cookie-settings .govuk-form-group')
   formGroup && formGroup.classList.add('govuk-form-group--error')
 
   var errorMessageSpan = document.createElement('span')

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -55,7 +55,7 @@ CookieSettings.prototype.submitSettingsForm = function (event) {
   }
   // the cookie choice must be set when form is submitted
   if (options.analytics === undefined) {
-    this.showErrorMessage()
+    this.showError()
     return false
   }
 
@@ -70,7 +70,7 @@ CookieSettings.prototype.submitSettingsForm = function (event) {
   }
 
   this.hideWarningMessage()
-  this.hideErrorMessage()
+  this.hideError()
   this.showConfirmationMessage()
 
   return false
@@ -93,21 +93,21 @@ CookieSettings.prototype.showConfirmationMessage = function () {
   confirmationMessage.style.display = 'block'
 }
 
-CookieSettings.prototype.showErrorMessage = function () {
-  var errorMessage = document.querySelector('#dm-cookie-settings-error')
-  if (errorMessage !== null) {
-    errorMessage.style.display = 'block'
+CookieSettings.prototype.showError = function () {
+  var errorSummary = document.querySelector('#dm-cookie-settings-error')
+  if (errorSummary !== null) {
+    errorSummary.style.display = 'block'
     document.body.scrollTop = document.documentElement.scrollTop = 0
   }
-  this.showInlineErrorMessage()
+  this.showErrorMessage()
 }
 
-CookieSettings.prototype.hideErrorMessage = function () {
-  var errorMessage = document.querySelector('#dm-cookie-settings-error')
-  if (errorMessage !== null) {
-    errorMessage.style.display = 'none'
+CookieSettings.prototype.hideError = function () {
+  var errorSummary = document.querySelector('#dm-cookie-settings-error')
+  if (errorSummary !== null) {
+    errorSummary.style.display = 'none'
   }
-  this.hideInlineErrorMessage()
+  this.hideErrorMessage()
 }
 
 CookieSettings.prototype.hideWarningMessage = function () {
@@ -117,28 +117,28 @@ CookieSettings.prototype.hideWarningMessage = function () {
   }
 }
 
-CookieSettings.prototype.hideInlineErrorMessage = function () {
-  var inlineErrorMessage = document.querySelector('#dm-cookie-settings-error-inline')
-  if (inlineErrorMessage !== null) {
-    inlineErrorMessage.style.display = 'none'
+CookieSettings.prototype.hideErrorMessage = function () {
+  var errorMessage = document.querySelector('#dm-cookie-settings-error-message')
+  if (errorMessage !== null) {
+    errorMessage.style.display = 'none'
   }
 
-  var inlineErrorHighlight = document.querySelector('.govuk-form-group--error')
-  inlineErrorHighlight && inlineErrorHighlight.classList.remove('govuk-form-group--error')
+  var errorMessageHighlight = document.querySelector('.govuk-form-group--error')
+  errorMessageHighlight && errorMessageHighlight.classList.remove('govuk-form-group--error')
 }
 
-CookieSettings.prototype.showInlineErrorMessage = function () {
+CookieSettings.prototype.showErrorMessage = function () {
   var firstFormGroup = document.querySelector('.govuk-form-group')
   firstFormGroup && firstFormGroup.classList.add('govuk-form-group--error')
 
-  var inlineErrorSpan = document.createElement('span')
-  inlineErrorSpan.setAttribute('id', 'dm-cookie-settings-error-inline')
-  inlineErrorSpan.className = 'govuk-error-message'
-  inlineErrorSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Select yes to accept analytics cookies'
+  var errorMessageSpan = document.createElement('span')
+  errorMessageSpan.setAttribute('id', 'dm-cookie-settings-error-message')
+  errorMessageSpan.className = 'govuk-error-message'
+  errorMessageSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Select yes to accept analytics cookies'
 
   var siblingElement = document.querySelector('govuk-radios govuk-radios--inline')
   var parentElement = siblingElement.parentElement
-  parentElement.insertBefore(inlineErrorSpan, siblingElement)
+  parentElement.insertBefore(errorMessageSpan, siblingElement)
 }
 
 CookieSettings.prototype.hideCookieBanner = function () {

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -99,6 +99,7 @@ CookieSettings.prototype.showErrorMessage = function () {
     errorMessage.style.display = 'block'
     document.body.scrollTop = document.documentElement.scrollTop = 0
   }
+  showInlineErrorMessage()
 }
 
 CookieSettings.prototype.hideErrorMessage = function () {
@@ -106,6 +107,7 @@ CookieSettings.prototype.hideErrorMessage = function () {
   if (errorMessage !== null) {
     errorMessage.style.display = 'none'
   }
+  hideInlineErrorMessage()
 }
 
 CookieSettings.prototype.hideWarningMessage = function () {
@@ -113,6 +115,30 @@ CookieSettings.prototype.hideWarningMessage = function () {
   if (warningMessage !== null) {
     warningMessage.style.display = 'none'
   }
+}
+
+function hideInlineErrorMessage () {
+  var inlineErrorMessage = document.querySelector('#dm-cookie-settings-error-inline')
+  if (inlineErrorMessage !== null) {
+    inlineErrorMessage.style.display = 'none'
+  }
+
+  var inlineErrorHighlight = document.querySelector('.govuk-form-group--error')
+  inlineErrorHighlight && inlineErrorHighlight.classList.remove('govuk-form-group--error')
+}
+
+function showInlineErrorMessage () {
+  var firstFormGroup = document.querySelector('.govuk-form-group')
+  firstFormGroup && firstFormGroup.classList.add('govuk-form-group--error')
+
+  var inlineErrorSpan = document.createElement('span')
+  inlineErrorSpan.setAttribute('id', 'dm-cookie-settings-error-inline')
+  inlineErrorSpan.className = 'govuk-error-message'
+  inlineErrorSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Please select \'Yes\' or \'No\''
+
+  var parentElement = document.getElementsByClassName('govuk-radios govuk-radios--inline')[0]
+  var grandparentElement = parentElement.parentElement
+  grandparentElement.insertBefore(inlineErrorSpan, parentElement)
 }
 
 CookieSettings.prototype.hideCookieBanner = function () {

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -134,7 +134,7 @@ CookieSettings.prototype.showInlineErrorMessage = function () {
   var inlineErrorSpan = document.createElement('span')
   inlineErrorSpan.setAttribute('id', 'dm-cookie-settings-error-inline')
   inlineErrorSpan.className = 'govuk-error-message'
-  inlineErrorSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Please select \'Yes\' or \'No\''
+  inlineErrorSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Select yes to accept analytics cookies'
 
   var siblingElement = document.querySelector('govuk-radios govuk-radios--inline')
   var parentElement = siblingElement.parentElement

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -128,15 +128,15 @@ CookieSettings.prototype.hideErrorMessage = function () {
 }
 
 CookieSettings.prototype.showErrorMessage = function () {
-  var firstFormGroup = document.querySelector('.govuk-form-group')
-  firstFormGroup && firstFormGroup.classList.add('govuk-form-group--error')
+  var formGroup = document.querySelector('#dm-cookie-settings, .govuk-form-group')
+  formGroup && formGroup.classList.add('govuk-form-group--error')
 
   var errorMessageSpan = document.createElement('span')
   errorMessageSpan.setAttribute('id', 'dm-cookie-settings-error-message')
   errorMessageSpan.className = 'govuk-error-message'
   errorMessageSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Select yes to accept analytics cookies'
 
-  var siblingElement = document.querySelector('govuk-radios govuk-radios--inline')
+  var siblingElement = document.querySelector('#cookie-settings-1, .govuk-radios--inline')
   var parentElement = siblingElement.parentElement
   parentElement.insertBefore(errorMessageSpan, siblingElement)
 }

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -136,9 +136,9 @@ function showInlineErrorMessage () {
   inlineErrorSpan.className = 'govuk-error-message'
   inlineErrorSpan.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Please select \'Yes\' or \'No\''
 
-  var parentElement = document.getElementsByClassName('govuk-radios govuk-radios--inline')[0]
-  var grandparentElement = parentElement.parentElement
-  grandparentElement.insertBefore(inlineErrorSpan, parentElement)
+  var siblingElement = document.getElementsByClassName('govuk-radios govuk-radios--inline')[0]
+  var parentElement = siblingElement.parentElement
+  parentElement.insertBefore(inlineErrorSpan, siblingElement)
 }
 
 CookieSettings.prototype.hideCookieBanner = function () {

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
@@ -137,13 +137,13 @@ describe('Cookie settings', () => {
       it('shows confirmation message and hides other messages', async () => {
         const $cookieSettings = await new CookieSettings(cookieSettingsForm)
         $cookieSettings.hideWarningMessage = jest.fn()
-        $cookieSettings.hideErrorMessage = jest.fn()
+        $cookieSettings.hideError = jest.fn()
         $cookieSettings.showConfirmationMessage = jest.fn()
 
         await $cookieSettings.submitSettingsForm(submitEvent)
 
         expect($cookieSettings.hideWarningMessage).toHaveBeenCalled()
-        expect($cookieSettings.hideErrorMessage).toHaveBeenCalled()
+        expect($cookieSettings.hideError).toHaveBeenCalled()
         expect($cookieSettings.showConfirmationMessage).toHaveBeenCalled()
       })
     })
@@ -168,13 +168,13 @@ describe('Cookie settings', () => {
       it('shows confirmation message and hides other messages', async () => {
         const $cookieSettings = await new CookieSettings(cookieSettingsForm)
         $cookieSettings.hideWarningMessage = jest.fn()
-        $cookieSettings.hideErrorMessage = jest.fn()
+        $cookieSettings.hideError = jest.fn()
         $cookieSettings.showConfirmationMessage = jest.fn()
 
         await $cookieSettings.submitSettingsForm(submitEvent)
 
         expect($cookieSettings.hideWarningMessage).toHaveBeenCalled()
-        expect($cookieSettings.hideErrorMessage).toHaveBeenCalled()
+        expect($cookieSettings.hideError).toHaveBeenCalled()
         expect($cookieSettings.showConfirmationMessage).toHaveBeenCalled()
       })
     })
@@ -198,11 +198,11 @@ describe('Cookie settings', () => {
 
       it('shows error message', async () => {
         const $cookieSettings = await new CookieSettings(cookieSettingsForm)
-        $cookieSettings.showErrorMessage = jest.fn()
+        $cookieSettings.showError = jest.fn()
 
         await $cookieSettings.submitSettingsForm(submitEvent)
 
-        expect($cookieSettings.showErrorMessage).toHaveBeenCalled()
+        expect($cookieSettings.showError).toHaveBeenCalled()
       })
     })
   })

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.test.js
@@ -106,7 +106,15 @@ describe('Cookie settings', () => {
     beforeEach(async () => {
       document.querySelector = jest.fn()
       // Create a fake element to get/set display attribute
-      document.querySelector.mockImplementation(() => { return { style: {} } })
+      document.querySelector.mockImplementation(() => {
+        return {
+          style: {},
+          classList: { remove: jest.fn(), add: jest.fn() },
+          parentElement: {
+            insertBefore: jest.fn()
+          }
+        }
+      })
     })
 
     describe('with No selected', () => {


### PR DESCRIPTION
this is part of https://trello.com/c/btdB5xBK/98-missing-contextual-error-messaging-on-cookie-settings-page
adds inline error message as per [design system error message component](https://design-system.service.gov.uk/components/error-message/)
![Screenshot 2020-05-22 at 11 34 27](https://user-images.githubusercontent.com/1764158/82659587-d7b3e900-9c20-11ea-9bcd-34333fd70d9f.png)
