### PR TITLE
Change gulp compile to always compile for both development and publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ and what task are run
 
 
 ## 1. Installing the repo
+
 After cloning this repository you will need to run `npm install`. After npm has successfully installed
 all packages and dependencies, an npm `postinstall` script will automatically run to do the following tasks:
 
@@ -76,6 +77,18 @@ Run `npm start dev`
 - compiles sass and js from `src` and places in `app/public`
 - watch task for any file changes to `src`, compiles and reloads the browser (using browsersync)
 - Start the webserver and reload the server if any server config changes (using nodemon)
+
+## 3. Testing features in apps
+
+Follow the steps in `docs/publishing-a-pre-release.md` to push a branch to GitHub as a release that can be consumed by other NodeJS apps.
+
+Alternatively, you can create a package locally using `npm run build`:
+
+    # in digitalmarketplace-govuk-frontend
+    $ npm run build
+    # change to an app
+    $ cd ../digitalmarketplace-user-frontend
+    $ npm install ../digitalmarketplace-govuk-frontend/package
 
 ## 3. Publishing
 

--- a/bin/release-to-branch.sh
+++ b/bin/release-to-branch.sh
@@ -20,9 +20,7 @@ fi
 git checkout -b $BRANCH_NAME
 
 # Build the package as normal
-export DMTASK='preparing'
 npm run build
-unset DMTASK
 
 echo "✍️ Commiting changed package"
 git add package/ --force

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -27,9 +27,7 @@ if [[ $continue_prompt != 'y' ]]; then
 fi
 
 npm run test
-export DMTASK='preparing'
 npm run build
-unset DMTASK
 
 if [ "$DRY_RUN" = "false" ]; then
   NPM_USER=$(npm whoami)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,11 @@
 const { series, parallel } = require('gulp')
 const clean = require('./tasks/gulp/clean')
 const copy = require('./tasks/gulp/copy')
-const compile = require('./tasks/gulp/compile-assets')
+const compileAssets = require('./tasks/gulp/compile-assets')
 
 const postInstall = series(clean.all, copy.development)
 
-const compile = series(parallel(compile.js, compile.scss))
+const compile = series(parallel(compileAssets.js, compileAssets.scss))
 
 const build = series(
   clean.pkg,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,15 +5,15 @@ const compile = require('./tasks/gulp/compile-assets')
 
 const postInstall = series(clean.all, copy.development)
 
-const compiling = series(parallel(compile.js, compile.scss))
+const compile = series(parallel(compile.js, compile.scss))
 
 const build = series(
   clean.pkg,
   copy.forPublishing,
-  compiling
+  compile
 )
 
 exports.build = build
-exports.compiling = compiling
+exports.compile = compile
 exports.postInstall = postInstall
 exports.default = exports.postInstall

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "gulp dev --gulpfile 'app/gulpfile.js'",
     "heroku": "node app/start.js",
-    "test": "standard && gulp compiling && jest",
+    "test": "standard && gulp compile && jest",
     "build": "gulp build --silent",
     "release": "./bin/release.sh",
     "release:dry-run": "npm run release -- --dry-run",

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -6,7 +6,6 @@ const rollup = require('gulp-better-rollup')
 const rollupPluginCommonjs = require('rollup-plugin-commonjs')
 const rollupPluginNodeResolve = require('rollup-plugin-node-resolve')
 const babel = require('gulp-babel')
-const gulpif = require('gulp-if')
 const rename = require('gulp-rename')
 const cssnano = require('cssnano')
 
@@ -26,17 +25,11 @@ const scss = () => {
 
 scss.displayName = 'Compile : SCSS'
 
-// Compile js task for preview ----------
+// Compile js task ----------------------
 // --------------------------------------
 const js = async (done) => {
   const dmFrontendSrc = 'src/digitalmarketplace/'
   const srcFiles = dmFrontendSrc + 'all.js'
-  let destPath = 'app/public/assets/javascript/'
-  const preparingToPublish = (process.env.DMTASK || 'development').trim().toLowerCase() === 'preparing'
-
-  if (preparingToPublish) {
-    destPath = 'package/digitalmarketplace/'
-  }
 
   await gulp.src([
     srcFiles,
@@ -63,13 +56,12 @@ const js = async (done) => {
     .pipe(babel({
       presets: ['@babel/preset-env']
     }))
-    .pipe(gulpif(preparingToPublish,
-      rename({
-        basename: 'digitalmarketplace-govuk-frontend',
-        extname: '.js'
-      })
-    ))
-    .pipe(gulp.dest(destPath))
+    .pipe(gulp.dest('app/public/assets/javascript/')) // save copy for review app
+    .pipe(rename({
+      basename: 'digitalmarketplace-govuk-frontend',
+      extname: '.js'
+    }))
+    .pipe(gulp.dest('package/digitalmarketplace/')) // save copy for publishing
 
   await done()
 }


### PR DESCRIPTION
This change should make it easier to test changes to digitalmarketplace-govuk-frontend locally; now running `gulp build` will always create everything needed for a package, so you can run

    # in digitalmarketplace-govuk-frontend
    $ npm run build
    # change to an app
    $ cd ../digitalmarketplace-user-frontend
    $ npm install ../digitalmarketplace-govuk-frontend/package

to use your local copy of digitalmarketplace-govuk-frontend.