### PR TITLE
Move govuk-frontend src from govuk-frontend to govuk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /app/public
 
 node_modules
-package/govuk-frontend/
+package/govuk
 package/digitalmarketplace/
-src/govuk-frontend
+src/govuk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ See below for Changelog examples.
 
 ## Unreleased
 
+💥 Breaking changes:
+
+- Move govuk-frontend templates and styles to `govuk/`
+
+  You must change any paths containing `govuk-frontend/` to use `govuk/` instead.
+
+  For example, to import govukInput you now write:
+
+  ```
+  {% from "govuk/components/input/macro.njk" import govukInput %}
+  ```
+
+  ([PR #151](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/151))
+
 🆕 New features:
 
   - New component: Digital Marketplace List Input component

--- a/app/app.js
+++ b/app/app.js
@@ -58,8 +58,8 @@ module.exports = (options) => {
 
   // Set up middleware to serve static assets
   app.use('/public', express.static('app/public/'))
-  app.use('/public/assets/govuk-frontend', express.static('node_modules/govuk-frontend/assets/'))
-  app.use('/public/assets/govuk-frontend/javascript', express.static('node_modules/govuk-frontend/'))
+  app.use('/public/assets/govuk-frontend', express.static('src/govuk/assets/'))
+  app.use('/public/assets/govuk-frontend/javascript', express.static('src/govuk/'))
 
   app.use('/docs', express.static(configPaths.sassdoc))
 

--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -2,7 +2,7 @@ $govuk-show-breakpoints: true;
 $govuk-images-path: "/public/assets/govuk-frontend/images/";
 $govuk-fonts-path: "/public/assets/govuk-frontend/fonts/";
 
-@import "govuk-frontend/all.scss";
+@import "govuk/all.scss";
 @import "digitalmarketplace/all.scss";
 @import "./partials/app";
 @import "./partials/banner";

--- a/app/views/layouts/all-components.njk
+++ b/app/views/layouts/all-components.njk
@@ -1,6 +1,6 @@
 {% extends "full-width.njk" %}
 
-{% from "govuk-frontend/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "macros/showExamples.njk" import showExamples %}
 
 {% set bodyClasses %}

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -1,4 +1,4 @@
-{% from "govuk-frontend/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "macros/showExamples.njk" import showExamples %}
 
 {% extends "full-width.njk" %}

--- a/app/views/macros/showExamples.njk
+++ b/app/views/macros/showExamples.njk
@@ -1,4 +1,4 @@
-{% from "govuk-frontend/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% macro showExamples(componentSlug, componentName, data, legacyQuery) %}
 

--- a/config/paths.test.json
+++ b/config/paths.test.json
@@ -1,5 +1,0 @@
-{
-  "dmSource": "src/digitalmarketplace/",
-  "dmComponents": "src/digitalmarketplace/components/",
-  "govukSource": "src/govuk-frontend/"
-}

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -7,10 +7,10 @@ const cheerio = require('cheerio')
 const nunjucks = require('nunjucks')
 const yaml = require('js-yaml')
 
-const configPaths = require('../config/paths.test.json')
+const configPaths = require('../config/paths.json')
 const { componentNameToMacroName } = require('./helper-functions.js')
 
-const nunjucksEnv = nunjucks.configure([configPaths.govukSource, configPaths.dmComponents], {
+const nunjucksEnv = nunjucks.configure([configPaths.src, configPaths.components], {
   trimBlocks: true,
   lstripBlocks: true
 })
@@ -65,7 +65,7 @@ function render (componentName, params, macros = false, children = false, mainWr
  */
 function getExamples (componentName) {
   const file = fs.readFileSync(
-    path.join(configPaths.dmComponents, componentName, `${componentName}.yaml`),
+    path.join(configPaths.components, componentName, `${componentName}.yaml`),
     'utf8'
   )
 

--- a/src/digitalmarketplace/components/alert/_alert.scss
+++ b/src/digitalmarketplace/components/alert/_alert.scss
@@ -1,5 +1,5 @@
-@import "../../../govuk-frontend/tools/all";
-@import "../../../govuk-frontend/helpers/all";
+@import "../../../govuk/tools/all";
+@import "../../../govuk/helpers/all";
 
 @include govuk-exports("digitalmarketplace/component/alert") {
 

--- a/src/digitalmarketplace/components/banner/_banner.scss
+++ b/src/digitalmarketplace/components/banner/_banner.scss
@@ -1,5 +1,5 @@
-@import "../../../govuk-frontend/tools/all";
-@import "../../../govuk-frontend/helpers/all";
+@import "../../../govuk/tools/all";
+@import "../../../govuk/helpers/all";
 
 @include govuk-exports("digitalmarketplace/component/banner") {
 

--- a/src/digitalmarketplace/components/cookie-banner/_cookie-banner.scss
+++ b/src/digitalmarketplace/components/cookie-banner/_cookie-banner.scss
@@ -1,13 +1,13 @@
-@import '../../../govuk-frontend/tools/all';
-@import '../../../govuk-frontend/helpers/all';
+@import '../../../govuk/tools/all';
+@import '../../../govuk/helpers/all';
 
 // Import govuk-frontend styling which this component depends on
 // It does not import twice if used by another component because
 // govuk-frontend is named in govuk-exports.
-@import '../../../govuk-frontend/objects/width-container';
-@import '../../../govuk-frontend/utilities/visually-hidden';
-@import '../../../govuk-frontend/core/typography';
-@import '../../../govuk-frontend/components/button/_button';
+@import '../../../govuk/objects/width-container';
+@import '../../../govuk/utilities/visually-hidden';
+@import '../../../govuk/core/typography';
+@import '../../../govuk/components/button/_button';
 
 @include govuk-exports("digitalmarketplace/component/cookie-banner") {
   // component should only be shown if JS is available, by the cookieMessage JS, so hide by default

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -1,4 +1,4 @@
-{% from "../../../govuk-frontend/components/footer/macro.njk" import govukFooter -%}
+{% from "../../../govuk/components/footer/macro.njk" import govukFooter -%}
 {{ govukFooter({
   navigation: [
     {

--- a/src/digitalmarketplace/components/header/_header.scss
+++ b/src/digitalmarketplace/components/header/_header.scss
@@ -1,5 +1,5 @@
-@import "../../../govuk-frontend/tools/all";
-@import "../../../govuk-frontend/helpers/all";
+@import "../../../govuk/tools/all";
+@import "../../../govuk/helpers/all";
 
 @include govuk-exports("digitalmarketplace/component/header") {
 

--- a/src/digitalmarketplace/components/header/template.njk
+++ b/src/digitalmarketplace/components/header/template.njk
@@ -1,4 +1,4 @@
-{% from "../../../govuk-frontend/components/header/macro.njk" import govukHeader -%}
+{% from "../../../govuk/components/header/macro.njk" import govukHeader -%}
 
 {% set user_logged_in = true if params.role else false %}
 {% set users_role = params.role|default(none) %}

--- a/src/digitalmarketplace/components/list-input/_list-input.scss
+++ b/src/digitalmarketplace/components/list-input/_list-input.scss
@@ -1,11 +1,11 @@
-@import "../../../govuk-frontend/settings/all";
-@import "../../../govuk-frontend/tools/all";
-@import "../../../govuk-frontend/helpers/all";
+@import "../../../govuk/settings/all";
+@import "../../../govuk/tools/all";
+@import "../../../govuk/helpers/all";
 
-@import "../../../govuk-frontend/components/error-message/error-message";
-@import "../../../govuk-frontend/components/fieldset/fieldset";
-@import "../../../govuk-frontend/components/hint/hint";
-@import "../../../govuk-frontend/components/input/input";
+@import "../../../govuk/components/error-message/error-message";
+@import "../../../govuk/components/fieldset/fieldset";
+@import "../../../govuk/components/hint/hint";
+@import "../../../govuk/components/input/input";
 
 @include govuk-exports("digitalmarketplace/component/list-input") {
   .dm-list-input__legend {

--- a/src/digitalmarketplace/components/list-input/template.njk
+++ b/src/digitalmarketplace/components/list-input/template.njk
@@ -1,9 +1,9 @@
-{%- from "../../../govuk-frontend/components/error-message/macro.njk" import govukErrorMessage -%}
-{%- from "../../../govuk-frontend/components/fieldset/macro.njk" import govukFieldset -%}
-{%- from "../../../govuk-frontend/components/button/macro.njk" import govukButton -%}
-{%- from "../../../govuk-frontend/components/hint/macro.njk" import govukHint -%}
-{%- from "../../../govuk-frontend/components/label/macro.njk" import govukLabel -%}
-{%- from "../../../govuk-frontend/components/input/macro.njk" import govukInput -%}
+{%- from "../../../govuk/components/error-message/macro.njk" import govukErrorMessage -%}
+{%- from "../../../govuk/components/fieldset/macro.njk" import govukFieldset -%}
+{%- from "../../../govuk/components/button/macro.njk" import govukButton -%}
+{%- from "../../../govuk/components/hint/macro.njk" import govukHint -%}
+{%- from "../../../govuk/components/label/macro.njk" import govukLabel -%}
+{%- from "../../../govuk/components/input/macro.njk" import govukInput -%}
 
 {#-  We need this for error messages and hints as well -#}
 {%- set id = params.id -%}

--- a/src/template.njk
+++ b/src/template.njk
@@ -1,1 +1,1 @@
-{% extends "govuk-frontend/template.njk" %}
+{% extends "govuk/template.njk" %}

--- a/tasks/gulp/clean.js
+++ b/tasks/gulp/clean.js
@@ -19,18 +19,18 @@ const cleanupFoldersOrFiles = async (srcToClean) => {
 }
 
 const src = async (done) => {
-  await cleanupFoldersOrFiles(['src/govuk-frontend'])
+  await cleanupFoldersOrFiles(['src/govuk', 'src/govuk-frontend'])
   await done()
 }
 src.displayName = 'clean:src'
-src.description = 'Cleans `govuk-frontend` folder from src'
+src.description = 'Cleans `govuk` folder from src'
 
 const pkg = async (done) => {
-  await cleanupFoldersOrFiles(['package/govuk-frontend', 'package/digitalmarketplace'])
+  await cleanupFoldersOrFiles(['package/govuk', 'package/govuk-frontend', 'package/digitalmarketplace'])
   await done()
 }
 pkg.displayName = 'clean:package'
-pkg.description = 'Cleans `govuk-frontend` and `digitalmarketplace` folder from package'
+pkg.description = 'Cleans `govuk` and `digitalmarketplace` folder from package'
 
 module.exports = {
   src,

--- a/tasks/gulp/copy.js
+++ b/tasks/gulp/copy.js
@@ -1,7 +1,17 @@
 const { src, dest, parallel } = require('gulp')
 const emoji = require('node-emoji')
+const fs = require('fs')
 const { green } = require('chalk')
 const log = require('fancy-log')
+
+// Get the path to govuk-frontend source code
+//
+// Supports both govuk-frontend v2 and govuk-frontend v3, even though the
+// source code is located in difference places for the two.
+const getGOVUKFrontendSrc = () => {
+  const isV3 = fs.existsSync('node_modules/govuk-frontend/govuk/')
+  return isV3 ? 'node_modules/govuk-frontend/govuk/**' : 'node_modules/govuk-frontend/**'
+}
 
 // @params logMsg - string to log out to terminal
 // @params - srcToCopy - array/string of folders/files to copy
@@ -14,16 +24,16 @@ const copy = async (logMsg, srcToCopy, destTo) => {
 
 const CopyForDev = async (done) => {
   await copy('Copying GOV.UK Frontend to src directory',
-    ['node_modules/govuk-frontend/**'],
-    'src/govuk-frontend'
+    [getGOVUKFrontendSrc()],
+    'src/govuk'
   )
   await done()
 }
 
 const copyGOVUKFrontendForPublishing = async (done) => {
   await copy('Copying GOV.UK Frontend to package directory',
-    ['node_modules/govuk-frontend/**'],
-    'package/govuk-frontend'
+    [getGOVUKFrontendSrc()],
+    'package/govuk'
   )
   await done()
 }


### PR DESCRIPTION
https://trello.com/c/qqAnOWNw/146-migrate-digitalmarketplace-govuk-frontend-to-use-govuk-frontend-v3

I think we want the location of govuk-frontend components and styles to be consistent with GOV.UK Design System and govuk-frontend v3.

This commit changes the location to be `govuk/`, rather than `govuk-frontend/`.

This means that any apps that migrate to accomodate this change won't then need to change paths again when migrating to govuk-frontend v3.