### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ See below for Changelog examples.
   @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all"
   ```
 
+  ([PR #153](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pulls/153))
+
 - Move govuk-frontend templates and styles to `govuk/`
 
   You must change any paths containing `govuk-frontend/` to use `govuk/` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See below for Changelog examples.
 
-## Unreleased
+## 1.0.0
 
 💥 Breaking changes:
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
💥 Breaking changes:

- Move Digital Marketplace files around

  We've moved some files around so their locations are consistent with govuk-frontend.

  - The Digital Marketplace JavaScript file is now found at `digitalmarketplace-govuk-frontend/digitalmarketplace/all.js`
  - The Digital Marketplace Sass file is now found at `digitalmarketplace-govuk-frontend/digitalmarketplace/all.scss`

  You must change how you copy or import Digital Marketplace JavaScript:

  ```
  // to copy Digital Marketplace JavaScript using gulp-include
  //= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all.js
  ```

  You may need to change how you import Digital Marketplace Sass:

  ```
  @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all"
  ```

  ([PR #153](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pulls/153))

- Move govuk-frontend templates and styles to `govuk/`

  You must change any paths containing `govuk-frontend/` to use `govuk/` instead.

  For example, to import govukInput you now write:

  ```
  {% from "govuk/components/input/macro.njk" import govukInput %}
  ```

  ([PR #151](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/151))

🆕 New features:

  - New component: Digital Marketplace List Input component
    - Use the component `{{ dmListInput({...}) }}`. For its parameters, see its README and/or YAML. For examples, see the review app.

🔧 Fixes:
  - Ability to wrap components with `<main>` to avoid accessibility errors. [PR #148](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/148)
  - Add title to iFrames. [PR #148](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/148)
  - Fix "open in new tab" links [PR #148](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/148)