### PR TITLE
Add aria-label to cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See below for Changelog examples.
 ## Unreleased
 
 🔧 Fixes:
+  - Give Cookie Banner an `aria-label` property [PR #161](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/161)
   - Remove focusable state from alert and banner [PR #158](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/158)
 
 ## 1.0.0

--- a/src/digitalmarketplace/components/cookie-banner/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/cookie-banner/__snapshots__/template.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cookie-banner component renders a cookie banner with visible content and buttons 1`] = `
-"<html><head></head><body><div id=\\"dm-cookie-banner\\" class=\\"dm-cookie-banner govuk-width-container\\" data-module=\\"dm-cookie-banner\\" role=\\"region\\" aria-describedby=\\"dm-cookie-banner__heading\\">
+"<html><head></head><body><div id=\\"dm-cookie-banner\\" class=\\"dm-cookie-banner govuk-width-container\\" data-module=\\"dm-cookie-banner\\" role=\\"region\\" aria-label=\\"Cookie Banner\\" aria-describedby=\\"dm-cookie-banner__heading\\">
   <div class=\\"dm-cookie-banner__wrapper\\">
     <h2 class=\\"dm-cookie-banner__heading govuk-heading-m\\" id=\\"dm-cookie-banner__heading\\">
       Can we store analytics cookies on your device?

--- a/src/digitalmarketplace/components/cookie-banner/template.njk
+++ b/src/digitalmarketplace/components/cookie-banner/template.njk
@@ -3,7 +3,7 @@
 {% set cookieInfoUrl = params.cookieInfoUrl if params.cookieInfoUrl else '/cookies' %}
 {% set cookieSettingsUrl = params.cookieSettingsUrl if params.cookieSettingsUrl else '/users/cookie-settings' %}
 
-<div id="{{ componentID }}" class="dm-cookie-banner govuk-width-container" data-module="dm-cookie-banner" role="region" aria-describedby="dm-cookie-banner__heading">
+<div id="{{ componentID }}" class="dm-cookie-banner govuk-width-container" data-module="dm-cookie-banner" role="region" aria-label="Cookie Banner" aria-describedby="dm-cookie-banner__heading">
   <div class="dm-cookie-banner__wrapper">
     <h2 class="dm-cookie-banner__heading govuk-heading-m" id="dm-cookie-banner__heading">
       Can we store analytics cookies on your device?


### PR DESCRIPTION
The cookie banner is a `region` but has no label, so fails WCAG 1.3.1.

![Screenshot 2020-08-04 at 08 20 59](https://user-images.githubusercontent.com/22524634/89264855-8c0fb980-d62b-11ea-8d8a-9352529985c2.png)

Giving it an `aria-label` fixes this.