### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ See below for Changelog examples.
 
 ## Unreleased
 
+## 1.0.1
+
 🔧 Fixes:
-  - Give Cookie Banner an `aria-label` property [PR #161](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/161)
-  - Remove focusable state from alert and banner [PR #158](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/158)
+  - The cookie banner component now has a `aria-label` property [PR #161](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/161)
+  - The alert and banner components no longer have a focusable state [PR #158](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/158)
 
 ## 1.0.0
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "govuk-frontend/all.js",
   "sass": "govuk-frontend/all.scss",
   "engines": {


### PR DESCRIPTION
🔧 Fixes:
  - The cookie banner component now has an `aria-label` property [PR #161](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/161)
  - The alert and banner components no longer have a focusable state [PR #158](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/158)