### PR TITLE
Adjust position of List Input numbered label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## Unreleased
+
+🔧 Fixes:
+
+  - The list input component input label numbers now align properly on smaller screens [PR #168](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/168)
+
 ## 1.1.0
 
 🆕 New features:

--- a/src/digitalmarketplace/components/list-input/_list-input.scss
+++ b/src/digitalmarketplace/components/list-input/_list-input.scss
@@ -39,10 +39,14 @@
     
         width: 1.5em;
         position: absolute;
-        top: 9px;
+        top: 11px;
         text-align: right;
         left: govuk-spacing(1);
         pointer-events: none;
+
+        @include govuk-media-query($from: tablet) {
+          top: 9px;
+        }
       }
 
       // Spacing for inputs which have errors


### PR DESCRIPTION
Previously this was being overridden in the app, so I missed the alignment of the input number label was getting a little high on smaller screens.

![Screenshot 2020-08-18 at 11 45 53](https://user-images.githubusercontent.com/22524634/90504082-6cf34a80-e148-11ea-8ffa-9c3bd0f18564.png)
