### PR TITLE
Unbundle govuk-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 package/govuk
 package/digitalmarketplace/
 src/govuk
+
+python-tests/__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ See below for Changelog examples.
 
 💥 Breaking changes:
 
-  - You should [add GOV.UK Frontend to your Sass load paths](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#simplify-sass-import-paths)
+  - GOV.UK Frontend has been removed from the package.
+    - You will need to install GOV.UK Frontend separately - we recommend using (npm)](docs/installation/installing-with-npm.md).
+    - You should ensure that GOV.UK Frontend templates are loaded into your templating environment. If you are using v3, including `node_modules/govuk-frontend` should be sufficient. If you are using v2, you will need to prefix the templates with `govuk` to ensure they are correctly located.
+    - You should [add GOV.UK Frontend to your Sass load paths](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#simplify-sass-import-paths). If you're using v2, you will have to make these available at `govuk/`.
 
 
 🆕 New features:

--- a/README.md
+++ b/README.md
@@ -3,31 +3,21 @@ Digital Marketplace GOV.UK Frontend ·
 [![Known Vulnerabilities](https://snyk.io/test/github/alphagov/digitalmarketplace-govuk-frontend/badge.svg?targetFile=package.json)](https://snyk.io/test/github/alphagov/digitalmarketplace-govuk-frontend?targetFile=package.json)
 =====================
 
-[Digital Marketplace] + [GOV.UK Frontend] = [Digital Marketplace GOV.UK Frontend]
-
-This repository does two things:
-
-- it provides a central repository for custom components used in the Digital Marketplace
-- it imports GOV.UK Frontend and serves it to Digital Marketplace frontend applications
-  where they can consume GOV.UK Frontend and all the custom components in a single dependency
+This repository provides a central repository for custom components used in the Digital Marketplace
 
 The problem we are trying to solve:
 
 - it is difficult to ensure that all our applications are using the same version of GOV.UK Frontend and digitalmarketplace-frontend-toolkit (which is being replaced).
 - it is difficult to ensure that we are only importing and using css/js for components we are actually using and not been removed.
 
-## GOV.UK Frontend
+## Dependencies
 
-GOV.UK Frontend contains the code you need to start building a user interface
-for government platforms and services.
-
-See live examples of GOV.UK Frontend components, and guidance on when to use
+* GOV.UK Frontend
+  * GOV.UK Frontend contains the code you need to start building a user interface for government platforms and services.
+  * See live examples of GOV.UK Frontend components, and guidance on when to use
 them in your service, in the [GOV.UK Design
 System](https://design-system.service.gov.uk/).
-
-### Contact the GOV.UK Frontend team
-
-GOV.UK Frontend is maintained by a team at Government Digital Service. If you want to know more about GOV.UK Frontend, please email the [Design System
+  * GOV.UK Frontend is maintained by a team at Government Digital Service. If you want to know more about GOV.UK Frontend, please email the [Design System
 team](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk) or get in touch with them on [Slack](https://ukgovernmentdigital.slack.com/messages/govuk-design-system).
 
 ## Digital Marketplace GOV.UK Frontend
@@ -45,6 +35,8 @@ Digital Marketplace GOV.UK Frontend is maintained by a team at Government Digita
 We recommend [installing Digital Marketplace GOV.UK Frontend using node package manager
 (npm)](docs/installation/installing-with-npm.md).
 
+**Make sure GOV.UK Frontend is installed**
+
 ### 2. Add GOV.UK Frontend to your Sass load paths
 
 Digital Marketplace GOV.UK Frontend relies on GOV.UK Frontend being available to Sass.
@@ -56,6 +48,12 @@ If you're using Node Sass you can add GOV.UK Frontend to your Sass load paths us
   includePaths: ['node_modules/digitalmarketplace-govuk-frontend']
 }
 ```
+
+### 3. Load templates from GOV.UK Frontend
+
+If you are using v2 of GOV.UK Frontend, you'll need to ensure the `node_modules/govuk-frontend` directory is loaded into your templating environment with a `govuk` prefix so that Digital Marketplace components can target the correct GOV.UK Frontend components.
+
+With v3, targetting the `node_modules/govuk-frontend` directory is sufficient, as there is already a `govuk` subfolder.
 
 ## Getting updates
 
@@ -77,10 +75,10 @@ and what task are run
 After cloning this repository you will need to run `npm install`. After npm has successfully installed
 all packages and dependencies, an npm `postinstall` script will automatically run to do the following tasks:
 
-- Removes `govuk-frontend` from `src`(if it exists)
-- Copy `govuk-frontend` from `node_modules` to `src`
+- Removes the `govuk` folder containing `govuk-frontend` from `src`(if it exists)
+- Copy `govuk-frontend` from `node_modules` to `src/govuk`
 
-The reason for copying `govuk-frontend` to `src` is to ensure that `src` mirrors what will eventually become `package` and it also helps with import file paths as they would have vary between `src` and `packaged`
+The reason for copying `govuk-frontend` to `src/govuk` is to ensure that `govuk/` is available for templates in testing and development environments.
 
 ## 2. Developing components/features and previewing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8503,7 +8503,8 @@
     "govuk-frontend": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
-      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw=="
+      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "del": "^5.1.0",
-    "govuk-frontend": "^2.13.0",
     "gulp": "^4.0.2",
     "gulp-postcss": "^8.0.0",
     "node-emoji": "^1.10.0",
@@ -72,6 +71,7 @@
     "cookie-parser": "^1.4.5",
     "cssnano": "^4.1.10",
     "express": "^4.17.1",
+    "govuk-frontend": "^2.13.0",
     "gulp-babel": "^8.0.0",
     "gulp-better-rollup": "^4.0.1",
     "gulp-if": "^3.0.0",

--- a/package/package.json
+++ b/package/package.json
@@ -2,6 +2,9 @@
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
   "version": "1.1.1",
+  "peerDependencies": {
+    "govuk-frontend": "^2.13.0"
+  },
   "main": "digitalmarketplace/all.js",
   "sass": "digitalmarketplace/all.scss",
   "engines": {

--- a/package/package.json
+++ b/package/package.json
@@ -2,8 +2,8 @@
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
   "version": "1.1.1",
-  "main": "govuk-frontend/all.js",
-  "sass": "govuk-frontend/all.scss",
+  "main": "digitalmarketplace/all.js",
+  "sass": "digitalmarketplace/all.scss",
   "engines": {
     "node": "10.19.0"
   },

--- a/tasks/gulp/clean.js
+++ b/tasks/gulp/clean.js
@@ -26,7 +26,7 @@ src.displayName = 'clean:src'
 src.description = 'Cleans `govuk` folder from src'
 
 const pkg = async (done) => {
-  await cleanupFoldersOrFiles(['package/govuk', 'package/govuk-frontend', 'package/digitalmarketplace'])
+  await cleanupFoldersOrFiles(['package/govuk', 'package/digitalmarketplace'])
   await done()
 }
 pkg.displayName = 'clean:package'

--- a/tasks/gulp/copy.js
+++ b/tasks/gulp/copy.js
@@ -23,21 +23,12 @@ const copy = async (logMsg, srcToCopy, destTo) => {
 }
 
 const CopyForDev = async (done) => {
-  await copy('Copying GOV.UK Frontend to src directory',
+  await copy('Copying GOV.UK Frontend to src directory for development',
     [getGOVUKFrontendSrc()],
     'src/govuk'
   )
   await done()
 }
-
-const copyGOVUKFrontendForPublishing = async (done) => {
-  await copy('Copying GOV.UK Frontend to package directory',
-    [getGOVUKFrontendSrc()],
-    'package/govuk'
-  )
-  await done()
-}
-copyGOVUKFrontendForPublishing.displayName = 'Copy: GOV.UK Frontend for Publishing'
 
 const copyDigitalMarketplaceForPublishing = async (done) => {
   await copy('Copying Digital Marketplace to package directory',
@@ -53,6 +44,5 @@ copyDigitalMarketplaceForPublishing.displayName = 'Copy: Digital Marketplace for
 
 module.exports = {
   development: CopyForDev,
-  forPublishing: parallel(copyDigitalMarketplaceForPublishing,
-    copyGOVUKFrontendForPublishing)
+  forPublishing: copyDigitalMarketplaceForPublishing
 }

--- a/tasks/gulp/copy.js
+++ b/tasks/gulp/copy.js
@@ -1,4 +1,4 @@
-const { src, dest, parallel } = require('gulp')
+const { src, dest } = require('gulp')
 const emoji = require('node-emoji')
 const fs = require('fs')
 const { green } = require('chalk')


### PR DESCRIPTION
https://trello.com/c/fhL8Zl8T/175-3-unbundle-govuk-frontend-from-digitalmarketplace-govuk-frontend

## Why
We want to be able to use digitalmarketplace-govuk-frontend with [LandRegistry/govuk-frontend-jinja](https://github.com/LandRegistry/govuk-frontend-jinja) and reduce the coupling with [govuk-frontend](https://github.com/alphagov/govuk-frontend).

## Testing
Local tests and the app are working.

There is a PR for the Briefs Frontend for an example of how to get a frontend app working with this change: https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/352