### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 See below for Changelog examples.
 
-## Unreleased
+## 2.0.0
 
 💥 Breaking changes:
 
-  - GOV.UK Frontend has been removed from the package.
+  - GOV.UK Frontend has been removed from the package. [PR #173](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/173)
     - You will need to install GOV.UK Frontend separately - we recommend using (npm)](docs/installation/installing-with-npm.md).
     - You should ensure that GOV.UK Frontend templates are loaded into your templating environment. If you are using v3, including `node_modules/govuk-frontend` should be sufficient. If you are using v2, you will need to prefix the templates with `govuk` to ensure they are correctly located.
     - You should [add GOV.UK Frontend to your Sass load paths](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#simplify-sass-import-paths). If you're using v2, you will have to make these available at `govuk/`.
 
-
 🆕 New features:
 
-  - You no longer need to use the govuk-frontend macros bundled with digitalmarketplace-govuk-frontend
+  - Component Nunjucks templates are now compatible with Jinja2 as-is. [PR #174](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/174)
+  - You no longer need to use the govuk-frontend macros bundled with digitalmarketplace-govuk-frontend [PR #171](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/171)
 
 🔧 Fixes:
 
-  - The component macros no longer use relative imports, which do not work with Jinja2
+  - The component macros no longer use relative imports, which do not work with Jinja2 [PR #171](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/171)
 
 ## 1.1.1
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION

## 2.0.0

💥 Breaking changes:

  - GOV.UK Frontend has been removed from the package. [PR #173](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/173)
    - You will need to install GOV.UK Frontend separately - we recommend using (npm)](docs/installation/installing-with-npm.md).
    - You should ensure that GOV.UK Frontend templates are loaded into your templating environment. If you are using v3, including `node_modules/govuk-frontend` should be sufficient. If you are using v2, you will need to prefix the templates with `govuk` to ensure they are correctly located.
    - You should [add GOV.UK Frontend to your Sass load paths](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#simplify-sass-import-paths). If you're using v2, you will have to make these available at `govuk/`.

🆕 New features:

  - Component Nunjucks templates are now compatible with Jinja2 as-is. [PR #174](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/174)
  - You no longer need to use the govuk-frontend macros bundled with digitalmarketplace-govuk-frontend [PR #171](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/171)

🔧 Fixes:

  - The component macros no longer use relative imports, which do not work with Jinja2 [PR #171](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/171)