### PR TITLE
Fix bug where Jinja dictsort would complain about undefined

### DIFF
--- a/python-tests/__snapshots__/test_templates.ambr
+++ b/python-tests/__snapshots__/test_templates.ambr
@@ -1,3 +1,28 @@
+# name: test_dm_alert_with_no_attributes
+  '
+  
+          
+          <div
+      data-module="dm-alert"
+      role="alert"
+      aria-label=""
+      class="dm-alert"
+      tabindex="-1"
+  >
+      <h2
+          class="dm-alert__title dm-alert__title--large"
+      >
+          
+      </h2>
+      
+          <div class="dm-alert__body">
+              Alert body
+          </div>
+      
+  </div>
+      
+  '
+---
 # name: test_template_renders[template_path0]
   '
   

--- a/python-tests/test_templates.py
+++ b/python-tests/test_templates.py
@@ -100,3 +100,17 @@ def test_template_renders(env, params, template_path, snapshot):
     template = env.get_template(template_path)
     template_output = template.render(params=params)
     assert template_output == snapshot
+
+
+def test_dm_alert_with_no_attributes(env, snapshot):
+    """Test that we don't get an undefined error when rendering dmAlert"""
+    # TODO: this test is here to catch a regression, ideally it would be
+    # replaced with a proper test suite for the component (see
+    # https://trello.com/c/gw8q0xdl)
+    template = env.from_string("""
+        {% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
+        {{ dmAlert({"text": "Alert body"}) }}
+    """)
+    template_output = template.render()
+
+    assert template_output == snapshot

--- a/src/digitalmarketplace/components/alert/template.njk
+++ b/src/digitalmarketplace/components/alert/template.njk
@@ -3,7 +3,7 @@
     role="alert"
     aria-label="{{ params.titleHtml|striptags if params.titleHtml else params.titleText }}"
     class="dm-alert{%- if params.type %} dm-alert--{{ params.type }}{% endif %}{%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute in (params.attributes | dictsort) if params.attributes %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
+    {%- for attribute in (params.attributes | default({}) | dictsort) %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
     tabindex="-1"
 >
     <h{% if params.headingLevel %}{{ params.headingLevel }}{% else %}2{% endif %}

--- a/src/digitalmarketplace/components/banner/template.njk
+++ b/src/digitalmarketplace/components/banner/template.njk
@@ -3,7 +3,7 @@
     role="region"
     aria-label="{{ params.title }}"
     class="dm-banner{%- if params.type %} dm-banner--{{ params.type }}{% endif %}{%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute in (params.attributes | dictsort) if params.attributes %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
+    {%- for attribute in (params.attributes | default({}) | dictsort) %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
 >
     <h{% if params.headingLevel %}{{ params.headingLevel }}{% else %}2{% endif %}
         class="dm-banner__title{% if params.html or params.text %} dm-banner__title--large{% endif %}"


### PR DESCRIPTION
In Jinja dictsort would raise an exception if dictsort was being passed undefined, for instance when a param was not present.

This caused issues with alphagov/digitalmarketplace-briefs-frontend#354