### PR TITLE
Adds Option Select component

### DIFF
--- a/src/digitalmarketplace/all.js
+++ b/src/digitalmarketplace/all.js
@@ -46,5 +46,6 @@ export {
   Analytics,
   CookieBanner,
   CookieSettings,
-  ListInput
+  ListInput,
+  OptionSelect
 }

--- a/src/digitalmarketplace/all.js
+++ b/src/digitalmarketplace/all.js
@@ -5,6 +5,7 @@ import * as Analytics from './components/analytics/analytics'
 import initAnalytics from './components/analytics/init'
 import { getConsentCookie } from './helpers/cookie/cookie-functions'
 import ListInput from './components/list-input/list-input'
+import OptionSelect from './components/option-select/option-select'
 
 function initAll (options) {
   // Set the options to an empty object by default if no options are passed.
@@ -31,6 +32,11 @@ function initAll (options) {
   var $ListInput = scope.querySelectorAll('[data-module="dm-list-input"]')
   $ListInput.forEach(function ($ListInput) {
     new ListInput($ListInput).init()
+  })
+
+  var $OptionSelect = scope.querySelectorAll('[data-module="dm-option-select"]')
+  $OptionSelect.forEach(function ($OptionSelect) {
+    new OptionSelect($OptionSelect).init()
   })
 }
 

--- a/src/digitalmarketplace/all.scss
+++ b/src/digitalmarketplace/all.scss
@@ -3,3 +3,4 @@
 @import "components/cookie-banner/cookie-banner";
 @import "components/header/header";
 @import "components/list-input/list-input";
+@import "components/option-select/option-select";

--- a/src/digitalmarketplace/components/option-select/README.md
+++ b/src/digitalmarketplace/components/option-select/README.md
@@ -1,0 +1,5 @@
+# Option select
+
+An option select is used for filter forms. It consists of a govukCheckboxes component which is wrapped by a collapsing/expanding element.
+
+It is based heavily on the Finder app's option select: https://github.com/alphagov/finder-frontend/blob/master/app/views/components/_option-select.html.erb

--- a/src/digitalmarketplace/components/option-select/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/option-select/__snapshots__/template.test.js.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List Input by default matches existing snapshot 1`] = `
+"<html><head></head><body><div class=\\"dm-option-select\\" data-module=\\"dm-option-select\\">
+    <h2 class=\\"dm-option-select__heading js-container-heading\\">
+      <span class=\\"dm-option-select__title js-container-button\\" id=\\"option-select-title-default\\">Default</span>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--up\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z\\"/></svg>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--down\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z\\"/></svg>
+    </h2>
+
+    <div role=\\"group\\" aria-labelledby=\\"option-select-title-default\\" class=\\"dm-option-select__container js-options-container\\" id=\\"default-options\\" tabindex=\\"-1\\">
+      <div class=\\"dm-option-select__container-inner js-auto-height-inner\\">
+      
+<div class=\\"govuk-form-group\\">
+<fieldset class=\\"govuk-fieldset\\">
+  <legend class=\\"govuk-fieldset__legend govuk-visually-hidden\\">
+    Default
+  </legend>
+  <div class=\\"govuk-checkboxes govuk-checkboxes--small\\">
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"default-1\\" name=\\"option-1\\" type=\\"checkbox\\" value=\\"1\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"default-1\\">
+        Option 1
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"default-2\\" name=\\"option-2\\" type=\\"checkbox\\" value=\\"2\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"default-2\\">
+        Option 2
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"default-3\\" name=\\"option-3\\" type=\\"checkbox\\" value=\\"3\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"default-3\\">
+        Option 3
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"default-4\\" name=\\"option-4\\" type=\\"checkbox\\" value=\\"4\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"default-4\\">
+        Option 4
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"default-5\\" name=\\"option-5\\" type=\\"checkbox\\" value=\\"5\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"default-5\\">
+        Option 5
+      </label>    </div>
+  </div>
+</fieldset>
+</div>
+
+      </div>
+    </div>
+
+</div>
+
+</body></html>"
+`;
+
+exports[`List Input when collapsed on load matches existing snapshot 1`] = `
+"<html><head></head><body><div class=\\"dm-option-select\\" data-module=\\"dm-option-select\\" data-closed-on-load=\\"true\\">
+    <h2 class=\\"dm-option-select__heading js-container-heading\\">
+      <span class=\\"dm-option-select__title js-container-button\\" id=\\"option-select-title-collapsed\\">Collapsed on load</span>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--up\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z\\"/></svg>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--down\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z\\"/></svg>
+    </h2>
+
+    <div role=\\"group\\" aria-labelledby=\\"option-select-title-collapsed\\" class=\\"dm-option-select__container js-options-container\\" id=\\"collapsed-options\\" tabindex=\\"-1\\">
+      <div class=\\"dm-option-select__container-inner js-auto-height-inner\\">
+      
+<div class=\\"govuk-form-group\\">
+<fieldset class=\\"govuk-fieldset\\">
+  <legend class=\\"govuk-fieldset__legend govuk-visually-hidden\\">
+    Collapsed on load
+  </legend>
+  <div class=\\"govuk-checkboxes govuk-checkboxes--small\\">
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"collapsed-1\\" name=\\"option-1\\" type=\\"checkbox\\" value=\\"1\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"collapsed-1\\">
+        Option 1
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"collapsed-2\\" name=\\"option-2\\" type=\\"checkbox\\" value=\\"2\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"collapsed-2\\">
+        Option 2
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"collapsed-3\\" name=\\"option-3\\" type=\\"checkbox\\" value=\\"3\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"collapsed-3\\">
+        Option 3
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"collapsed-4\\" name=\\"option-4\\" type=\\"checkbox\\" value=\\"4\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"collapsed-4\\">
+        Option 4
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"collapsed-5\\" name=\\"option-5\\" type=\\"checkbox\\" value=\\"5\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"collapsed-5\\">
+        Option 5
+      </label>    </div>
+  </div>
+</fieldset>
+</div>
+
+      </div>
+    </div>
+
+</div>
+
+</body></html>"
+`;
+
+exports[`List Input when few options matches existing snapshot 1`] = `
+"<html><head></head><body><div class=\\"dm-option-select\\" data-module=\\"dm-option-select\\">
+    <h2 class=\\"dm-option-select__heading js-container-heading\\">
+      <span class=\\"dm-option-select__title js-container-button\\" id=\\"option-select-title-short\\">With few options</span>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--up\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z\\"/></svg>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--down\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z\\"/></svg>
+    </h2>
+
+    <div role=\\"group\\" aria-labelledby=\\"option-select-title-short\\" class=\\"dm-option-select__container js-options-container\\" id=\\"short-options\\" tabindex=\\"-1\\">
+      <div class=\\"dm-option-select__container-inner js-auto-height-inner\\">
+      
+<div class=\\"govuk-form-group\\">
+<fieldset class=\\"govuk-fieldset\\">
+  <legend class=\\"govuk-fieldset__legend govuk-visually-hidden\\">
+    With few options
+  </legend>
+  <div class=\\"govuk-checkboxes govuk-checkboxes--small\\">
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"short-1\\" name=\\"option-1\\" type=\\"checkbox\\" value=\\"1\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"short-1\\">
+        Option 1
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"short-2\\" name=\\"option-2\\" type=\\"checkbox\\" value=\\"2\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"short-2\\">
+        Option 2
+      </label>    </div>
+  </div>
+</fieldset>
+</div>
+
+      </div>
+    </div>
+
+</div>
+
+</body></html>"
+`;
+
+exports[`List Input with option pre-checked matches existing snapshot 1`] = `
+"<html><head></head><body><div class=\\"dm-option-select\\" data-module=\\"dm-option-select\\">
+    <h2 class=\\"dm-option-select__heading js-container-heading\\">
+      <span class=\\"dm-option-select__title js-container-button\\" id=\\"option-select-title-with_checked_value_set\\">List of options</span>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--up\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z\\"/></svg>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--down\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z\\"/></svg>
+    </h2>
+
+    <div role=\\"group\\" aria-labelledby=\\"option-select-title-with_checked_value_set\\" class=\\"dm-option-select__container js-options-container\\" id=\\"list_of_vegetables\\" tabindex=\\"-1\\">
+      <div class=\\"dm-option-select__container-inner js-auto-height-inner\\">
+      
+<div class=\\"govuk-form-group\\">
+<fieldset class=\\"govuk-fieldset\\">
+  <legend class=\\"govuk-fieldset__legend govuk-visually-hidden\\">
+    List of options
+  </legend>
+  <div class=\\"govuk-checkboxes govuk-checkboxes--small\\">
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"with_checked_value_set-1\\" name=\\"with_checked_value_set\\" type=\\"checkbox\\" value=\\"potatoes\\" checked>
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"with_checked_value_set-1\\">
+        Potatoes
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"carrots\\" name=\\"with_checked_value_set\\" type=\\"checkbox\\" value=\\"carrots\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"carrots\\">
+        Carrots
+      </label>    </div>
+    <div class=\\"govuk-checkboxes__item\\">
+      <input class=\\"govuk-checkboxes__input\\" id=\\"mash\\" name=\\"with_checked_value_set\\" type=\\"checkbox\\" value=\\"mash\\">
+      <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"mash\\">
+        Mash
+      </label>    </div>
+  </div>
+</fieldset>
+</div>
+
+      </div>
+    </div>
+
+</div>
+
+</body></html>"
+`;

--- a/src/digitalmarketplace/components/option-select/_option-select.scss
+++ b/src/digitalmarketplace/components/option-select/_option-select.scss
@@ -76,8 +76,7 @@
   .dm-option-select__icon {
     display: none;
     position: absolute;
-    top: 4px; /* Override for v2 */
-    /*top: 0; /* v3 */
+    top: 0;
     left: 9px;
     width: 30px;
     height: 40px;
@@ -98,6 +97,10 @@
   
   .dm-option-select__container-inner {
     padding: govuk-spacing(1) 13px;
+
+    .govuk-form-group {
+        margin-bottom: govuk-spacing(1);
+    }
   }
     
   .js-enabled {
@@ -140,3 +143,4 @@
       display: block;
     }
   }
+  

--- a/src/digitalmarketplace/components/option-select/_option-select.scss
+++ b/src/digitalmarketplace/components/option-select/_option-select.scss
@@ -1,0 +1,142 @@
+.dm-option-select {
+    position: relative;
+    padding: 0 0 govuk-spacing(2);
+    margin-bottom: govuk-spacing(2);
+    border-bottom: 1px solid $govuk-border-colour;
+  
+    @include govuk-media-query($from: desktop) {
+      // Redefine scrollbars on desktop where these lists are scrollable
+      // so they are always visible in option lists
+      ::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: 7px;
+      }
+  
+      ::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+  
+        // scss-lint:disable ColorVariable
+        background-color: rgba(0, 0, 0, .5);
+        -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.87);
+      }
+    }
+  }
+  
+  .dm-option-select__title {
+    @include govuk-font(19);
+    margin: 0;
+  }
+  
+  .dm-option-select__button {
+    z-index: 1;
+    background: none;
+    border: 0;
+    text-align: left;
+    padding: 0;
+    cursor: pointer;
+    color: $govuk-link-colour;
+  
+    &:hover {
+      text-decoration: underline;
+    }
+  
+    &::-moz-focus-inner {
+      border: 0;
+    }
+  
+    &:focus {
+      outline: none;
+      text-decoration: none;
+      /* Replace with: */
+      /*@include govuk-focused-text;*/
+      outline: 3px solid transparent;
+      color: $govuk-input-border-colour;
+      background-color: $govuk-focus-colour;
+      box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-input-border-colour;
+      text-decoration: none;
+    }
+  
+    &[disabled] {
+      background-image: none;
+      color: inherit;
+    }
+  
+    // Extend the touch area of the button to span the heading
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 2;
+    }
+  }
+  
+  .dm-option-select__icon {
+    display: none;
+    position: absolute;
+    top: 4px; /* Override for v2 */
+    /*top: 0; /* v3 */
+    left: 9px;
+    width: 30px;
+    height: 40px;
+    fill: govuk-colour("black");
+  }
+  
+  .dm-option-select__container {
+    position: relative;
+    max-height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    background-color: govuk-colour("white");
+  
+    &:focus {
+      outline: 0;
+    }
+  }
+  
+  .dm-option-select__container-inner {
+    padding: govuk-spacing(1) 13px;
+  }
+    
+  .js-enabled {
+    .dm-option-select__heading {
+      position: relative;
+      padding: 10px 8px 5px 43px;
+    }
+  
+    [aria-expanded="true"] ~ .dm-option-select__icon--up {
+      display: block;
+    }
+  
+    [aria-expanded="false"] ~ .dm-option-select__icon--down {
+      display: block;
+    }
+  
+    .dm-option-select__container {
+      height: 200px;
+    }
+  
+    [data-closed-on-load="true"] .dm-option-select__container {
+      display: none;
+    }
+  }
+  
+  .dm-option-select__selected-counter {
+    @include govuk-font($size: 14);
+    color: $govuk-text-colour;
+    margin-top: 3px;
+  }
+  
+  .dm-option-select.js-closed {
+    .dm-option-select__container {
+      display: none;
+    }
+  }
+  
+  .dm-option-select.js-opened {
+    .dm-option-select__container {
+      display: block;
+    }
+  }

--- a/src/digitalmarketplace/components/option-select/macro.njk
+++ b/src/digitalmarketplace/components/option-select/macro.njk
@@ -1,0 +1,3 @@
+{% macro dmOptionSelect(params) %}
+  {%- include "digitalmarketplace/components/option-select/template.njk" -%}
+{% endmacro %}

--- a/src/digitalmarketplace/components/option-select/option-select.js
+++ b/src/digitalmarketplace/components/option-select/option-select.js
@@ -1,5 +1,174 @@
 function OptionSelect($module) {
+  this.$optionSelect = $module
+  this.$options = this.$optionSelect.querySelectorAll("input[type='checkbox']")
+  this.$optionsContainer = this.$optionSelect.querySelector('.js-options-container')
+  this.$optionList = this.$optionsContainer.querySelector('.js-auto-height-inner')
+  this.$allCheckboxes = this.$optionsContainer.querySelectorAll('.govuk-checkboxes__item')
+  this.checkedCheckboxes = []
+}
 
+OptionSelect.prototype.init = function () {
+  // Attach listener to update checked count
+  this.$optionSelect.addEventListener('change', function(event) {
+    var $changedEl = event.target
+    if ($changedEl.tagName === 'INPUT' && $changedEl.type === 'checkbox') {
+      this.updateCheckedCount()
+    }
+  }.bind(this))
+
+  // Replace div.container-head with a button
+  this.replaceHeadingSpanWithButton()
+
+  // Add js-collapsible class to parent for CSS
+  this.$optionSelect.classList.add('js-collapsible')
+
+  // Add open/close listeners
+  this.$optionSelect.querySelector('.js-container-button').addEventListener('click', this.toggleOptionSelect.bind(this))
+  if (this.$optionSelect.dataset.closedOnLoad === "true") {
+    this.close()
+  } else {
+    this.setupHeight()
+  }
+
+  var checkedString = this.checkedString()
+  if (checkedString) {
+    this.attachCheckedCounter(checkedString)
+  }
+}
+
+OptionSelect.prototype.getAllCheckedCheckboxes = function getAllCheckedCheckboxes () {
+  this.checkedCheckboxes = []
+  var that = this
+
+  this.$allCheckboxes.forEach(function (i) {
+    if (i.querySelector('input[type=checkbox]').checked) {
+      that.checkedCheckboxes.push(i)
+    }
+  }, this)
+}
+
+OptionSelect.prototype.replaceHeadingSpanWithButton = function replaceHeadingSpanWithButton () {
+  /* Replace the span within the heading with a button element. This is based on feedback from Léonie Watson.
+    * The button has all of the accessibility hooks that are used by screen readers and etc.
+    * We do this in the JavaScript because if the JavaScript is not active then the button shouldn't
+    * be there as there is no JS to handle the click event.
+  */
+  var $containerHead = this.$optionSelect.querySelector('.js-container-button')
+  var jsContainerHeadHTML = $containerHead.innerHTML
+
+  // Create button and replace the preexisting html with the button.
+  var $button = document.createElement('button')
+  $button.classList.add('js-container-button', 'dm-option-select__title', 'dm-option-select__button')
+  // Add type button to override default type submit when this component is used within a form
+  $button.setAttribute('type', 'button')
+  $button.setAttribute('aria-expanded', true)
+  $button.setAttribute('id', $containerHead.id)
+  $button.setAttribute('aria-controls', this.$optionsContainer.id)
+  $button.innerHTML = jsContainerHeadHTML
+  $containerHead.replaceWith($button)
+}
+
+OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter (checkedString) {
+  this.$optionSelect.querySelector('.js-container-button')
+  .insertAdjacentHTML('afterend', '<div class="dm-option-select__selected-counter js-selected-counter">' + checkedString + '</div>')
+}
+
+OptionSelect.prototype.updateCheckedCount = function updateCheckedCount () {
+  var checkedString = this.checkedString()
+  var checkedStringElement = this.$optionSelect.querySelector('.js-selected-counter')
+
+  if (checkedString) {
+    if (checkedStringElement) {
+      checkedStringElement.textContent = checkedString
+    } else {
+      this.attachCheckedCounter(checkedString)
+    }
+  } else {
+    checkedStringElement.remove()
+  }
+}
+
+OptionSelect.prototype.checkedString = function checkedString () {
+  this.getAllCheckedCheckboxes()
+  var count = this.checkedCheckboxes.length
+  var checkedString = false
+  if (count > 0) {
+    checkedString = count + ' selected'
+  }
+
+  return checkedString
+}
+
+OptionSelect.prototype.toggleOptionSelect = function toggleOptionSelect (e) {
+  if (this.isClosed()) {
+    this.open()
+  } else {
+    this.close()
+  }
+  e.preventDefault()
+}
+
+OptionSelect.prototype.open = function open () {
+  if (this.isClosed()) {
+    this.$optionSelect.querySelector('.js-container-button').setAttribute('aria-expanded', true)
+    this.$optionSelect.classList.remove('js-closed')
+    this.$optionSelect.classList.add('js-opened')
+    if (!this.$optionsContainer.style.height) {
+      this.setupHeight()
+    }
+  }
+}
+
+OptionSelect.prototype.close = function close () {
+  this.$optionSelect.classList.remove('js-opened')
+  this.$optionSelect.classList.add('js-closed')
+  this.$optionSelect.querySelector('.js-container-button').setAttribute('aria-expanded', false)
+}
+
+OptionSelect.prototype.isClosed = function isClosed () {
+  return this.$optionSelect.classList.contains('js-closed')
+}
+
+OptionSelect.prototype.setContainerHeight = function setContainerHeight (height) {
+  this.$optionsContainer.style.height = height
+}
+
+OptionSelect.prototype.isCheckboxVisible = function isCheckboxVisible (index, option) {
+  var $checkbox = $(option)
+  var initialOptionContainerHeight = this.$optionsContainer.clientHeight
+  var optionListOffsetTop = this.$optionList.offset().top
+  var distanceFromTopOfContainer = $checkbox.offset().top - optionListOffsetTop
+  return distanceFromTopOfContainer < initialOptionContainerHeight
+}
+
+OptionSelect.prototype.getVisibleCheckboxes = function getVisibleCheckboxes () {
+  var visibleCheckboxes = this.$options.filter(this.isCheckboxVisible.bind(this))
+  // add an extra checkbox, if the label of the first is too long it collapses onto itself
+  visibleCheckboxes = visibleCheckboxes.add(this.$options[visibleCheckboxes.length])
+  return visibleCheckboxes
+}
+
+OptionSelect.prototype.setupHeight = function setupHeight () {
+  var initialOptionContainerHeight = this.$optionsContainer.clientHeight
+  var height = this.$optionList.offsetHeight
+
+  // check whether this is hidden by progressive disclosure,
+  // because height calculations won't work
+  if (this.$optionsContainer.offsetParent === null) {
+    initialOptionContainerHeight = 200
+    height = 200
+  }
+
+  // Resize if the list is only slightly bigger than its container
+  if (height < initialOptionContainerHeight + 50) {
+    this.setContainerHeight(height + 1)
+    return
+  }
+
+  // Resize to cut last item cleanly in half
+  var lastVisibleCheckbox = this.getVisibleCheckboxes().last()
+  var position = lastVisibleCheckbox.parent()[0].offsetTop // parent element is relative
+  this.setContainerHeight(position + (lastVisibleCheckbox.height() / 1.5))
 }
 
 export default OptionSelect;

--- a/src/digitalmarketplace/components/option-select/option-select.js
+++ b/src/digitalmarketplace/components/option-select/option-select.js
@@ -1,0 +1,5 @@
+function OptionSelect($module) {
+
+}
+
+export default OptionSelect;

--- a/src/digitalmarketplace/components/option-select/option-select.js
+++ b/src/digitalmarketplace/components/option-select/option-select.js
@@ -1,4 +1,4 @@
-function OptionSelect($module) {
+function OptionSelect ($module) {
   this.$optionSelect = $module
   this.$options = this.$optionSelect.querySelectorAll("input[type='checkbox']")
   this.$optionsContainer = this.$optionSelect.querySelector('.js-options-container')
@@ -9,7 +9,7 @@ function OptionSelect($module) {
 
 OptionSelect.prototype.init = function () {
   // Attach listener to update checked count
-  this.$optionSelect.addEventListener('change', function(event) {
+  this.$optionSelect.addEventListener('change', function (event) {
     var $changedEl = event.target
     if ($changedEl.tagName === 'INPUT' && $changedEl.type === 'checkbox') {
       this.updateCheckedCount()
@@ -24,7 +24,7 @@ OptionSelect.prototype.init = function () {
 
   // Add open/close listeners
   this.$optionSelect.querySelector('.js-container-button').addEventListener('click', this.toggleOptionSelect.bind(this))
-  if (this.$optionSelect.dataset.closedOnLoad === "true") {
+  if (this.$optionSelect.dataset.closedOnLoad === 'true') {
     this.close()
   } else {
     this.setupHeight()
@@ -65,12 +65,13 @@ OptionSelect.prototype.replaceHeadingSpanWithButton = function replaceHeadingSpa
   $button.setAttribute('id', $containerHead.id)
   $button.setAttribute('aria-controls', this.$optionsContainer.id)
   $button.innerHTML = jsContainerHeadHTML
-  $containerHead.replaceWith($button)
+  $containerHead.insertAdjacentHTML('afterend', $button.outerHTML)
+  $containerHead.remove()
 }
 
 OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter (checkedString) {
   this.$optionSelect.querySelector('.js-container-button')
-  .insertAdjacentHTML('afterend', '<div class="dm-option-select__selected-counter js-selected-counter">' + checkedString + '</div>')
+    .insertAdjacentHTML('afterend', '<div class="dm-option-select__selected-counter js-selected-counter">' + checkedString + '</div>')
 }
 
 OptionSelect.prototype.updateCheckedCount = function updateCheckedCount () {
@@ -130,21 +131,22 @@ OptionSelect.prototype.isClosed = function isClosed () {
 }
 
 OptionSelect.prototype.setContainerHeight = function setContainerHeight (height) {
-  this.$optionsContainer.style.height = height
+  this.$optionsContainer.style.height = height + 'px'
 }
 
-OptionSelect.prototype.isCheckboxVisible = function isCheckboxVisible (index, option) {
-  var $checkbox = $(option)
+OptionSelect.prototype.isCheckboxVisible = function isCheckboxVisible ($checkbox) {
   var initialOptionContainerHeight = this.$optionsContainer.clientHeight
-  var optionListOffsetTop = this.$optionList.offset().top
-  var distanceFromTopOfContainer = $checkbox.offset().top - optionListOffsetTop
+  var optionListOffsetTop = this.$optionList.getBoundingClientRect().top + document.body.scrollTop
+  var distanceFromTopOfContainer = ($checkbox.getBoundingClientRect().top + document.body.scrollTop) - optionListOffsetTop
   return distanceFromTopOfContainer < initialOptionContainerHeight
 }
 
 OptionSelect.prototype.getVisibleCheckboxes = function getVisibleCheckboxes () {
-  var visibleCheckboxes = this.$options.filter(this.isCheckboxVisible.bind(this))
+  var visibleCheckboxes = ([].slice.call(this.$options)).filter(this.isCheckboxVisible.bind(this))
   // add an extra checkbox, if the label of the first is too long it collapses onto itself
-  visibleCheckboxes = visibleCheckboxes.add(this.$options[visibleCheckboxes.length])
+  if (visibleCheckboxes.length < this.$options) {
+    visibleCheckboxes.push(this.$options[visibleCheckboxes.length])
+  }
   return visibleCheckboxes
 }
 
@@ -166,9 +168,10 @@ OptionSelect.prototype.setupHeight = function setupHeight () {
   }
 
   // Resize to cut last item cleanly in half
-  var lastVisibleCheckbox = this.getVisibleCheckboxes().last()
-  var position = lastVisibleCheckbox.parent()[0].offsetTop // parent element is relative
-  this.setContainerHeight(position + (lastVisibleCheckbox.height() / 1.5))
+  var visibleCheckboxes = this.getVisibleCheckboxes()
+  var lastVisibleCheckbox = visibleCheckboxes[visibleCheckboxes.length - 1]
+  var position = lastVisibleCheckbox.parentNode.offsetTop // parent element is relative
+  this.setContainerHeight(position + (parseFloat(window.getComputedStyle(lastVisibleCheckbox, null).height.replace('px', '')) / 1.5))
 }
 
-export default OptionSelect;
+export default OptionSelect

--- a/src/digitalmarketplace/components/option-select/option-select.test.js
+++ b/src/digitalmarketplace/components/option-select/option-select.test.js
@@ -1,0 +1,111 @@
+const configPaths = require('../../../../config/paths.json')
+const PORT = configPaths.ports.test
+
+// URLs
+const BASE_URL = 'http://localhost:' + PORT
+const DEFAULT_EXAMPLE_URL = BASE_URL + '/components/option-select/preview'
+const COLLAPSED_EXAMPLE_URL = BASE_URL + '/components/option-select/with-options-collapsed/preview'
+const FEW_OPTIONS_EXAMPLE_URL = BASE_URL + '/components/option-select/with-few-options/preview'
+
+describe('/components/option-select', () => {
+  describe('/components/option-select/preview', () => {
+    describe('when JavaScript is unavailable or fails', () => {
+      beforeAll(async () => {
+        await page.setJavaScriptEnabled(false)
+      })
+
+      afterAll(async () => {
+        await page.setJavaScriptEnabled(true)
+      })
+
+      beforeEach(async () => {
+        await page.goto(DEFAULT_EXAMPLE_URL, { waitUntil: 'load' })
+      })
+
+      it('does not display SVG up/down arrows', async () => {
+        const arrowIcons = await page.$$('.dm-option-select__icon')
+        await page.waitForSelector('.dm-option-select__icon', { visible: false })
+        expect(arrowIcons.length).toBe(2)
+      })
+
+      it('displays all checkboxes', async () => {
+        await page.waitForSelector('.govuk-checkboxes__item', { visible: true })
+        const checkboxes = await page.$$('.govuk-checkboxes__item')
+        expect(checkboxes.length).toBe(5)
+      })
+    })
+
+    describe('when JavaScript is available', () => {
+      beforeAll(async () => {
+        await page.setJavaScriptEnabled(true)
+      })
+
+      beforeEach(async () => {
+        await page.goto(DEFAULT_EXAMPLE_URL, { waitUntil: 'load' })
+      })
+
+      it('displays SVG up/down arrows', async () => {
+        await page.waitForSelector('.dm-option-select__icon', { visible: true })
+        const arrowIcons = await page.$$('.dm-option-select__icon')
+        expect(arrowIcons.length).toBe(2)
+      })
+
+      it('can collapse and expand', async () => {
+        await page.click('.dm-option-select__button')
+        await page.waitForSelector('.govuk-checkboxes', { visible: false })
+        expect(await page.$$('.dm-option-select__button[aria-expanded="false"]')).toBeTruthy()
+
+        await page.click('.dm-option-select__button')
+        await page.waitForSelector('.govuk-checkboxes', { visible: true })
+        expect(await page.$('.dm-option-select__button[aria-expanded="true"]')).toBeTruthy()
+      })
+
+      it('increments and decrements checked counter when checkbox checked and unchecked', async () => {
+        await page.click('.govuk-checkboxes__input#default-1')
+        await page.click('.govuk-checkboxes__input#default-2')
+        await page.click('.govuk-checkboxes__input#default-3')
+        await page.click('.govuk-checkboxes__input#default-4')
+        await page.click('.govuk-checkboxes__input#default-5')
+        await page.waitForSelector('.dm-option-select__selected-counter', { visible: true })
+        const counter = await page.$('.dm-option-select__selected-counter')
+        const counterText = await page.evaluate(counter => counter.textContent, counter)
+        expect(counterText).toEqual('5 selected')
+
+        await page.click('.govuk-checkboxes__input#default-1')
+        await page.click('.govuk-checkboxes__input#default-2')
+        await page.click('.govuk-checkboxes__input#default-3')
+        await page.click('.govuk-checkboxes__input#default-4')
+        await page.click('.govuk-checkboxes__input#default-5')
+        await expect(page).not.toMatchElement('.dm-option-select__selected-counter')
+      })
+    })
+  })
+
+  describe('/components/option-select/with-options-collapsed/preview', () => {
+    beforeEach(async () => {
+      await page.goto(COLLAPSED_EXAMPLE_URL, { waitUntil: 'load' })
+    })
+
+    it('can begin with the option select closed on load', async () => {
+      const container = await page.$$('.dm-option-select[data-closed-on-load="true"]')
+      expect(container.length).toBe(1)
+
+      await page.waitForSelector('.govuk-checkboxes', { visible: false })
+      expect(await page.$('.dm-option-select__button[aria-expanded="false"]')).toBeTruthy()
+    })
+  })
+
+  describe('/components/option-select/with-few-options/preview', () => {
+    beforeEach(async () => {
+      await page.goto(FEW_OPTIONS_EXAMPLE_URL, { waitUntil: 'load' })
+    })
+
+    it('overrides default height if not many options', async () => {
+      const containerHeight = await page.evaluate(() => {
+        const container = document.querySelector('.dm-option-select__container')
+        return parseInt((container.style.height).slice(0, -2))
+      })
+      expect(containerHeight).toBeLessThan(200)
+    })
+  })
+})

--- a/src/digitalmarketplace/components/option-select/option-select.yaml
+++ b/src/digitalmarketplace/components/option-select/option-select.yaml
@@ -1,0 +1,37 @@
+params:
+- name: title
+  type: string
+  required: true
+  description: The title of the option select
+- name: name
+  type: string
+  required: true
+  description: The name of the option select element
+- name: items
+  type: array
+  required: true
+  description: The checkbox items
+- name: closed_on_load
+  type: boolean
+  description: Whether to collapse the filter by default
+
+examples:
+  - name: default
+    description: 'With JavaScript enabled, a list input should display at least two inputs, including at least one empty input.'
+    data:
+      name: "example-title"
+      title: "Example filter"
+      items: 
+        - text: 'Option 1'
+          name: 'option-1'
+          value: '1'
+        - text: 'Option 2'
+          name: 'option-2'
+          value: '2'
+        - text: 'Option 3'
+          name: 'option-3'
+          value: '3'
+        - text: 'Option 4'
+          name: 'option-4'
+          value: '4'
+      closed_on_load: true

--- a/src/digitalmarketplace/components/option-select/option-select.yaml
+++ b/src/digitalmarketplace/components/option-select/option-select.yaml
@@ -7,20 +7,24 @@ params:
   type: string
   required: true
   description: The name of the option select element
+- name: options_container_id
+  type: string
+  required: true
+  description: The ID of the container for the Checkboxes component
 - name: items
   type: array
   required: true
-  description: The checkbox items
+  description: The checkbox items. See https://design-system.service.gov.uk/components/checkboxes/#options-checkboxes-example--items
 - name: closed_on_load
   type: boolean
-  description: Whether to collapse the filter by default
+  description: Whether to collapse the filter. Defaults to False.
 
 examples:
   - name: default
-    description: 'With JavaScript enabled, a list input should display at least two inputs, including at least one empty input.'
+    description: 'A basic option select'
     data:
-      name: "example-title"
-      title: "Example filter"
+      name: "default"
+      title: "Default"
       items: 
         - text: 'Option 1'
           name: 'option-1'
@@ -34,4 +38,59 @@ examples:
         - text: 'Option 4'
           name: 'option-4'
           value: '4'
+        - text: 'Option 5'
+          name: 'option-5'
+          value: '5'
+      options_container_id: 'default-options'
+  - name: with options collapsed
+    description: 'An option select with the property closed_on_load set to true should collapse by default.'
+    data:
+      name: "collapsed"
+      title: "Collapsed on load"
+      items: 
+        - text: 'Option 1'
+          name: 'option-1'
+          value: '1'
+        - text: 'Option 2'
+          name: 'option-2'
+          value: '2'
+        - text: 'Option 3'
+          name: 'option-3'
+          value: '3'
+        - text: 'Option 4'
+          name: 'option-4'
+          value: '4'
+        - text: 'Option 5'
+          name: 'option-5'
+          value: '5'
+      options_container_id: 'collapsed-options'
       closed_on_load: true
+  - name: with few options
+    description: 'A short option select'
+    data:
+      name: "short"
+      title: "With few options"
+      items: 
+        - text: 'Option 1'
+          name: 'option-1'
+          value: '1'
+        - text: 'Option 2'
+          name: 'option-2'
+          value: '2'
+      options_container_id: 'short-options'
+  - name: with option pre checked
+    description: 'An option select with an option pre-checked'
+    data:
+      name: 'with_checked_value_set'
+      title: 'List of options'
+      options_container_id: list_of_vegetables
+      items:
+      - value: potatoes
+        text: Potatoes
+        checked: true
+      - value: carrots
+        text: Carrots
+        id: carrots
+      - value: mash
+        text: Mash
+        id: mash

--- a/src/digitalmarketplace/components/option-select/template.njk
+++ b/src/digitalmarketplace/components/option-select/template.njk
@@ -1,3 +1,36 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes -%}
 
-<div class="dm-option-select" data-module="dm-option-select">
+{% set title_id = "option-select-title-" + params.name %}
+{% set closed_on_load = True if params.closed_on_load %}
+
+<div 
+    class="dm-option-select"
+    data-module="dm-option-select"
+    {% if params.closed_on_load %} data-closed-on-load="true" {% endif %}
+    {% if params.aria_controls_id %} data-input-aria-controls="{{ params.aria_controls_id }}" {% endif %}
+>
+    <h2 class="dm-option-select__heading js-container-heading">
+      <span class="dm-option-select__title js-container-button" id="{{ title_id }}">{{ params.title }}</span>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="dm-option-select__icon dm-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="dm-option-select__icon dm-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+    </h2>
+
+    <div role="group" aria-labelledby="{{ title_id }}" class="dm-option-select__container js-options-container" id="{{ params.options_container_id }}" tabindex="-1">
+      <div class="dm-option-select__container-inner js-auto-height-inner">
+      {{ govukCheckboxes({
+        "idPrefix": params.name,
+        "name": params.name,
+        "classes": "govuk-checkboxes--small",
+        "fieldset": {
+          "legend": {
+            "html": params.title,
+            "classes": "govuk-visually-hidden"
+          }
+        },
+        "items": params.items
+      })}}
+      </div>
+    </div>
+
+</div>
+

--- a/src/digitalmarketplace/components/option-select/template.njk
+++ b/src/digitalmarketplace/components/option-select/template.njk
@@ -1,0 +1,3 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes -%}
+
+<div class="dm-option-select" data-module="dm-option-select">

--- a/src/digitalmarketplace/components/option-select/template.test.js
+++ b/src/digitalmarketplace/components/option-select/template.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers.js')
+
+const examples = getExamples('option-select')
+
+describe('List Input', () => {
+  describe('by default', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples.default)
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples.default, false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a heading for the option select box containing the title', async () => {
+      const $ = render('option-select', examples.default)
+      const title = $('.dm-option-select__title').text().trim()
+
+      expect(title).toEqual('Default')
+    })
+
+    it('renders a container with the ID passed in', async () => {
+      const $ = render('option-select', examples.default)
+      const container = $('#default-options.dm-option-select__container')
+
+      expect(container.length).toBe(1)
+    })
+
+    it('renders a set of checkboxes', async () => {
+      const $ = render('option-select', examples.default)
+      const govukCheckboxes = $('.govuk-checkboxes')
+
+      expect(govukCheckboxes.length).toBe(1)
+
+      const checkboxes = $('.govuk-checkboxes__item')
+
+      expect(checkboxes.length).toBe(5)
+    })
+  })
+
+  describe('when collapsed on load', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with options collapsed'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples['with options collapsed'], false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+  })
+
+  describe('when few options', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with few options'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples['with few options'], false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+  })
+
+  describe('with option pre-checked', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with option pre checked'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples['with option pre checked'], false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a checked checkbox', async () => {
+      const $ = render('option-select', examples['with option pre checked'])
+      const selectedCheckbox = $('#with_checked_value_set-1')
+
+      expect(selectedCheckbox.length).toBe(1)
+      expect(selectedCheckbox.attr('checked')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/VCANsToa/233-3-replace-search-filters-with-govuk-checkbox-groups-option-select

The Option Select component is heavily based on the Finder Frontend component: https://github.com/alphagov/finder-frontend/blob/master/app/views/components/_option-select.html.erb

It creates a collapsible container with checkboxes. If checkboxes are selected, a count is displayed and updated. We don't include the search text input from Finder.

Test this in operation by running this branch of the Buyer frontend locally: https://github.com/alphagov/digitalmarketplace-buyer-frontend/tree/bk-replace-filters-with-checkboxes 

### Option select on Buyer search pages:
![Screenshot 2020-09-24 at 08 02 43](https://user-images.githubusercontent.com/22524634/94111722-596c8b00-fe3c-11ea-9fef-bf9589a5dd0c.png)
