### PR TITLE
Use camelCase on Option Select, not snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See below for Changelog examples.
 
+## Unreleased
+
+🔧 Fixes:
+
+  - Option Select now uses camelCase instead of snake_case to match govuk-frontend [PR #186](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/186)
+
+
 ## 2.2.0
 
 🆕 New features:

--- a/src/digitalmarketplace/components/option-select/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/option-select/__snapshots__/template.test.js.snap
@@ -48,9 +48,7 @@ exports[`List Input by default matches existing snapshot 1`] = `
 
       </div>
     </div>
-
 </div>
-
 </body></html>"
 `;
 
@@ -102,9 +100,7 @@ exports[`List Input when collapsed on load matches existing snapshot 1`] = `
 
       </div>
     </div>
-
 </div>
-
 </body></html>"
 `;
 
@@ -141,9 +137,7 @@ exports[`List Input when few options matches existing snapshot 1`] = `
 
       </div>
     </div>
-
 </div>
-
 </body></html>"
 `;
 
@@ -185,8 +179,6 @@ exports[`List Input with option pre-checked matches existing snapshot 1`] = `
 
       </div>
     </div>
-
 </div>
-
 </body></html>"
 `;

--- a/src/digitalmarketplace/components/option-select/option-select.yaml
+++ b/src/digitalmarketplace/components/option-select/option-select.yaml
@@ -7,7 +7,7 @@ params:
   type: string
   required: true
   description: The name of the option select element
-- name: options_container_id
+- name: optionsContainerId
   type: string
   required: true
   description: The ID of the container for the Checkboxes component
@@ -15,7 +15,7 @@ params:
   type: array
   required: true
   description: The checkbox items. See https://design-system.service.gov.uk/components/checkboxes/#options-checkboxes-example--items
-- name: closed_on_load
+- name: closedOnLoad
   type: boolean
   description: Whether to collapse the filter. Defaults to False.
 
@@ -41,7 +41,7 @@ examples:
         - text: 'Option 5'
           name: 'option-5'
           value: '5'
-      options_container_id: 'default-options'
+      optionsContainerId: 'default-options'
   - name: with options collapsed
     description: 'An option select with the property closed_on_load set to true should collapse by default.'
     data:
@@ -63,8 +63,8 @@ examples:
         - text: 'Option 5'
           name: 'option-5'
           value: '5'
-      options_container_id: 'collapsed-options'
-      closed_on_load: true
+      optionsContainerId: 'collapsed-options'
+      closedOnLoad: true
   - name: with few options
     description: 'A short option select'
     data:
@@ -77,13 +77,13 @@ examples:
         - text: 'Option 2'
           name: 'option-2'
           value: '2'
-      options_container_id: 'short-options'
+      optionsContainerId: 'short-options'
   - name: with option pre checked
     description: 'An option select with an option pre-checked'
     data:
       name: 'with_checked_value_set'
       title: 'List of options'
-      options_container_id: list_of_vegetables
+      optionsContainerId: list_of_vegetables
       items:
       - value: potatoes
         text: Potatoes

--- a/src/digitalmarketplace/components/option-select/template.njk
+++ b/src/digitalmarketplace/components/option-select/template.njk
@@ -1,21 +1,21 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes -%}
 
-{% set title_id = "option-select-title-" + params.name %}
-{% set closed_on_load = True if params.closed_on_load %}
+{% set titleId = "option-select-title-" + params.name %}
+{% set closedOnLoad = True if params.closedOnLoad %}
 
 <div 
     class="dm-option-select"
     data-module="dm-option-select"
-    {% if params.closed_on_load %} data-closed-on-load="true" {% endif %}
-    {% if params.aria_controls_id %} data-input-aria-controls="{{ params.aria_controls_id }}" {% endif %}
+    {% if params.closedOnLoad %} data-closed-on-load="true" {% endif %}
+    {% if params.ariaControlsId %} data-input-aria-controls="{{ params.ariaControlsId }}" {% endif %}
 >
     <h2 class="dm-option-select__heading js-container-heading">
-      <span class="dm-option-select__title js-container-button" id="{{ title_id }}">{{ params.title }}</span>
+      <span class="dm-option-select__title js-container-button" id="{{ titleId }}">{{ params.title }}</span>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="dm-option-select__icon dm-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="dm-option-select__icon dm-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
     </h2>
 
-    <div role="group" aria-labelledby="{{ title_id }}" class="dm-option-select__container js-options-container" id="{{ params.options_container_id }}" tabindex="-1">
+    <div role="group" aria-labelledby="{{ titleId }}" class="dm-option-select__container js-options-container" id="{{ params.optionsContainerId }}" tabindex="-1">
       <div class="dm-option-select__container-inner js-auto-height-inner">
       {{ govukCheckboxes({
         "idPrefix": params.name,
@@ -31,6 +31,4 @@
       })}}
       </div>
     </div>
-
 </div>
-


### PR DESCRIPTION
Components should match govuk-frontend as much as possible, so let's switch the snake_case on Option Select params to camelCase.

This will need to be updated in the Buyer App when we bump the release of this package there.