### PR TITLE
Fix IE11 option select bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## Unreleased
+
+🔧 Fixes:
+
+  - Option Select now works properly in IE11. [PR #193](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/193)
+
 ## 2.4.0
 
 🆕 New features:

--- a/src/digitalmarketplace/components/option-select/option-select.js
+++ b/src/digitalmarketplace/components/option-select/option-select.js
@@ -66,7 +66,7 @@ OptionSelect.prototype.replaceHeadingSpanWithButton = function replaceHeadingSpa
   $button.setAttribute('aria-controls', this.$optionsContainer.id)
   $button.innerHTML = jsContainerHeadHTML
   $containerHead.insertAdjacentHTML('afterend', $button.outerHTML)
-  $containerHead.remove()
+  $containerHead.parentNode.removeChild($containerHead)
 }
 
 OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter (checkedString) {
@@ -85,7 +85,7 @@ OptionSelect.prototype.updateCheckedCount = function updateCheckedCount () {
       this.attachCheckedCounter(checkedString)
     }
   } else {
-    checkedStringElement.remove()
+    checkedStringElement.parentNode.removeChild(checkedStringElement)
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/AIVquUYj/1988-ccsrequests-re-g-cloud-12-filters-not-working

IE11 does not support `element.remove()`, so we can replace with `element.parentNode.removeChild(element)`

Tested on Browserstack and local Windows VM.