### PR TITLE
Add attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See below for Changelog examples.
 
+## Unreleased
+
+🆕 New features:
+
+  - New component: Digital Marketplace Attachment component
+    - Use the component `{{ dmAttachment({...}) }}`. For its parameters, see its README and/or YAML. For examples, see the review app. [PR #200](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/200)
+
 ## 2.4.1
 
 🔧 Fixes:

--- a/src/digitalmarketplace/all.scss
+++ b/src/digitalmarketplace/all.scss
@@ -5,4 +5,5 @@
 @import "components/list-input/list-input";
 @import "components/option-select/option-select";
 @import "components/search-box/search-box";
+@import "components/attachment/attachment";
 @import "components/previous-next-pagination/previous-next-pagination";

--- a/src/digitalmarketplace/components/attachment/README.md
+++ b/src/digitalmarketplace/components/attachment/README.md
@@ -1,0 +1,5 @@
+# Option select
+
+An option select is used for filter forms. It consists of a govukCheckboxes component which is wrapped by a collapsing/expanding element.
+
+It is based heavily on the Finder app's option select: https://github.com/alphagov/finder-frontend/blob/master/app/views/components/_option-select.html.erb

--- a/src/digitalmarketplace/components/attachment/README.md
+++ b/src/digitalmarketplace/components/attachment/README.md
@@ -1,5 +1,5 @@
-# Option select
+# Attachment
 
-An option select is used for filter forms. It consists of a govukCheckboxes component which is wrapped by a collapsing/expanding element.
+An attachment is used to link to a document which can be downloaded. It is heavily based on the [GOV.UK Publishing Components Attachment](https://components.publishing.service.gov.uk/component-guide/attachment)
 
-It is based heavily on the Finder app's option select: https://github.com/alphagov/finder-frontend/blob/master/app/views/components/_option-select.html.erb
+See attachment.yaml for the parameters that can be passed to the component.

--- a/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Attachment as text only matches existing snapshot 1`] = `
+"<html><head></head><body><div class=\\"dm-option-select\\" data-module=\\"dm-option-select\\">
+    <h2 class=\\"dm-option-select__heading js-container-heading\\">
+      <span class=\\"dm-option-select__title js-container-button\\" id=\\"option-select-title-undefined\\"></span>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--up\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z\\"/></svg>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--down\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z\\"/></svg>
+    </h2>
+
+    <div role=\\"group\\" aria-labelledby=\\"option-select-title-undefined\\" class=\\"dm-option-select__container js-options-container\\" id tabindex=\\"-1\\">
+      <div class=\\"dm-option-select__container-inner js-auto-height-inner\\">
+      
+<div class=\\"govuk-form-group\\">
+<fieldset class=\\"govuk-fieldset\\">
+  <div class=\\"govuk-checkboxes govuk-checkboxes--small\\">
+  </div>
+</fieldset>
+</div>
+
+      </div>
+    </div>
+</div>
+</body></html>"
+`;
+
+exports[`Attachment by default matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--doc\\" version=\\"1.1\\" viewBox=\\"0 0 84 120\\" width=\\"84\\" height=\\"120\\" aria-hidden=\\"true\\">
+            <path d=\\"M74.85 5v106H5\\" fill=\\"none\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"/>
+            <path d=\\"M79.85 10v106H10\\" fill=\\"none\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Default attachment</a>
+      </h2>
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment if pdf matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Portable Document Format attachment</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span></p>
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment if spreadsheet matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.csv\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--csv\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z\\" stroke-width=\\"0\\"/>
+            <path d=\\"M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z\\" stroke-width=\\"0\\"/>
+            <path d=\\"M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5\\" fill=\\"none\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.csv\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Comma-separated values attachment</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Comma-separated Values\\" class=\\"dm-attachment__abbr\\">CSV</abbr></span></p>
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment if unknown filetype matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.txt\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--doc\\" version=\\"1.1\\" viewBox=\\"0 0 84 120\\" width=\\"84\\" height=\\"120\\" aria-hidden=\\"true\\">
+            <path d=\\"M74.85 5v106H5\\" fill=\\"none\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"/>
+            <path d=\\"M79.85 10v106H10\\" fill=\\"none\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.txt\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Unknown filetype attachment</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\">txt</span></p>
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment with alternative format HTML matches existing snapshot 1`] = `
+"<html><head></head><body><div class=\\"dm-option-select\\" data-module=\\"dm-option-select\\">
+    <h2 class=\\"dm-option-select__heading js-container-heading\\">
+      <span class=\\"dm-option-select__title js-container-button\\" id=\\"option-select-title-undefined\\"></span>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--up\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z\\"/></svg>
+      <svg version=\\"1.1\\" viewBox=\\"0 0 1024 1024\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"dm-option-select__icon dm-option-select__icon--down\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z\\"/></svg>
+    </h2>
+
+    <div role=\\"group\\" aria-labelledby=\\"option-select-title-undefined\\" class=\\"dm-option-select__container js-options-container\\" id tabindex=\\"-1\\">
+      <div class=\\"dm-option-select__container-inner js-auto-height-inner\\">
+      
+<div class=\\"govuk-form-group\\">
+<fieldset class=\\"govuk-fieldset\\">
+  <div class=\\"govuk-checkboxes govuk-checkboxes--small\\">
+  </div>
+</fieldset>
+</div>
+
+      </div>
+    </div>
+</div>
+</body></html>"
+`;
+
+exports[`Attachment with alternative format contact email matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with alternative format contact email</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span></p>
+        <details class=\\"govuk-details\\">
+  <summary class=\\"govuk-details__summary\\">
+    <span class=\\"govuk-details__summary-text\\">
+      Request an accessible format
+    </span>
+  </summary>
+  <div class=\\"govuk-details__text\\">
+        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href=\\"mailto:help@digitalmarketplace.service.gov.uk\\" target=\\"_blank\\" class=\\"govuk-link\\">help@digitalmarketplace.service.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+
+  </div>
+</details>
+
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment with file size matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with file size</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span>, <span class=\\"dm-attachment__attribute\\">21.5 KB</span>
+</p>
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment with page count matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with page count</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span>, <span class=\\"dm-attachment__attribute\\">12 pages</span>
+</p>
+    </div>
+  </section>
+</body></html>"
+`;

--- a/src/digitalmarketplace/components/attachment/_attachment.scss
+++ b/src/digitalmarketplace/components/attachment/_attachment.scss
@@ -1,0 +1,76 @@
+$thumbnail-width: 99px;
+$thumbnail-height: 140px;
+$thumbnail-border-width: 5px;
+$thumbnail-background: govuk-colour("white");
+$thumbnail-border-colour: rgba(11, 12, 12, .1);
+$thumbnail-shadow-colour: rgba(11, 12, 12, .4);
+$thumbnail-shadow-width: 0 2px 2px;
+$thumbnail-icon-border-colour: $govuk-border-colour;
+
+.dm-attachment {
+  @include govuk-font(19);
+  @include govuk-clearfix;
+  position: relative;
+
+  .govuk-details__summary {
+    @include govuk-font($size: 14)
+  }
+}
+
+.dm-attachment__thumbnail {
+  position: relative;
+  width: auto;
+  margin-right: govuk-spacing(5);
+  margin-bottom: govuk-spacing(3);
+  padding: $thumbnail-border-width;
+  float: left;
+}
+
+.dm-attachment__thumbnail-image {
+  display: block;
+  width: auto; // for IE8
+  max-width: $thumbnail-width;
+  height: $thumbnail-height;
+  border: $thumbnail-border-colour; // for IE9 & IE10
+  outline: $thumbnail-border-width solid $thumbnail-border-colour;
+  background: $thumbnail-background;
+  box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
+  fill: $thumbnail-icon-border-colour;
+  stroke: $thumbnail-icon-border-colour;
+}
+
+.dm-attachment__details {
+  padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
+
+  .dm-details {
+    word-break: break-word;
+    word-wrap: break-word;
+  }
+}
+
+.dm-attachment__title {
+  @include govuk-font($size: 27);
+  margin: 0 0 govuk-spacing(3);
+}
+
+.dm-attachment__link {
+  line-height: 1.29;
+}
+
+.dm-attachment__metadata {
+  @include govuk-font($size: 14);
+  margin: 0 0 govuk-spacing(3);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.dm-attachment__metadata--compact {
+  margin-bottom: 0;
+}
+
+.dm-attachment__abbr {
+  text-decoration: none;
+  cursor: help;
+}

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -2,7 +2,7 @@ params:
 - name: link
   type: object
   required: true
-  description: The title of the attached document
+  description: Link details
   params:
   - name: href
     type: string
@@ -55,6 +55,13 @@ examples:
         text: "Portable Document Format attachment"
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
+  - name: unknown filetype
+    description: 'An unknown filetype'
+    data:
+      link:
+        text: "Unknown filetype attachment"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.txt"
+      contentType: 'txt'
   - name: with file size
     description: 'Attachment with file size'
     data:

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -1,0 +1,57 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: The title of the attached document
+- name: href
+  type: string
+  required: true
+  description: The href for the attached document
+- name: contentType
+  type: string
+  description: The filetype of the attached document (eg - 'text/csv')
+- name: fileSize
+  type: string
+  description: The file size of the attached document. This should be a human-readable size like "25 KB" or "1.2 MB"
+- name: numberOfPages
+  type: integer
+  description: Number of pages in the attached document
+- name: alternativeFormatHtml
+  type: string
+  description: Information on how to request an accessible format
+- name: alternativeFormatContactEmail
+  type: string
+  description: Used to provide an email to request an accessible format
+
+examples:
+  - name: default
+    description: 'A basic attachment'
+    data:
+      text: "Default attachment"
+      href: "https://digitalmarketplace.service.gov.uk/attachment"
+  - name: spreadsheet
+    description: 'A spreadsheet attachment'
+    data:
+      text: "Comma-separated values attachment"
+      href: "https://digitalmarketplace.service.gov.uk/attachment.csv"
+      contentType: 'text/csv'
+  - name: pdf
+    description: 'A PDF attachment'
+    data:
+      text: "Portable Document Format attachment"
+      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+  - name: with file size
+    description: 'Attachment with file size'
+    data:
+      text: "Attachment with file size"
+      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      fileSize: '21.5 KB'
+  - name: with page count
+    description: 'Attachment with page count'
+    data:
+      text: "Attachment with page count"
+      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      numberOfPages: 12

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -18,7 +18,7 @@ params:
   description: Number of pages in the attached document
 - name: alternativeFormatHtml
   type: string
-  description: Information on how to request an accessible format
+  description: Information on how to request an accessible format.
 - name: alternativeFormatContactEmail
   type: string
   description: Used to provide an email to request an accessible format
@@ -55,3 +55,17 @@ examples:
       href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       numberOfPages: 12
+  - name: with alternative format contact email
+    description: 'Attachment with alternative format contact email'
+    data:
+      text: "Attachment with alternative format contact email"
+      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      alternativeFormatContactEmail: 'help@digitalmarketplace.service.gov.uk'
+  - name: with alternative format HTML
+    description: 'Attachment with alternative format HTML'
+    data:
+      text: "Attachment with alternative format HTML"
+      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      alternativeFormatHtml: 'If you need help with this file, please <a href="https://www.digitalmarketplace.service.gov.uk" class="govuk-link">contact us via our contact form</a>.'

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -1,12 +1,23 @@
 params:
-- name: text
-  type: string
+- name: link
+  type: object
   required: true
   description: The title of the attached document
-- name: href
-  type: string
-  required: true
-  description: The href for the attached document
+  params:
+  - name: href
+    type: string
+    required: true
+    description: The href for the attached document
+  - name: text
+    type: string
+    required: true
+    description: The title of the attached document
+  - name: textOnly
+    type: boolean
+    description: Whether to display the link only
+  - name: classes
+    type: string
+    description: Classes to apply to the link
 - name: contentType
   type: string
   description: The filetype of the attached document (eg - 'text/csv')
@@ -27,45 +38,62 @@ examples:
   - name: default
     description: 'A basic attachment'
     data:
-      text: "Default attachment"
-      href: "https://digitalmarketplace.service.gov.uk/attachment"
+      link:
+        text: "Default attachment"
+        href: "https://digitalmarketplace.service.gov.uk/attachment"
   - name: spreadsheet
     description: 'A spreadsheet attachment'
     data:
-      text: "Comma-separated values attachment"
-      href: "https://digitalmarketplace.service.gov.uk/attachment.csv"
+      link:
+        text: "Comma-separated values attachment"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.csv"
       contentType: 'text/csv'
   - name: pdf
     description: 'A PDF attachment'
     data:
-      text: "Portable Document Format attachment"
-      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      link:
+        text: "Portable Document Format attachment"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
   - name: with file size
     description: 'Attachment with file size'
     data:
-      text: "Attachment with file size"
-      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      link:
+        text: "Attachment with file size"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       fileSize: '21.5 KB'
   - name: with page count
     description: 'Attachment with page count'
     data:
-      text: "Attachment with page count"
-      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      link:
+        text: "Attachment with page count"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       numberOfPages: 12
   - name: with alternative format contact email
     description: 'Attachment with alternative format contact email'
     data:
-      text: "Attachment with alternative format contact email"
-      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      link:
+        text: "Attachment with alternative format contact email"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       alternativeFormatContactEmail: 'help@digitalmarketplace.service.gov.uk'
   - name: with alternative format HTML
     description: 'Attachment with alternative format HTML'
     data:
-      text: "Attachment with alternative format HTML"
-      href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      link:
+        text: "Attachment with alternative format HTML"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       alternativeFormatHtml: 'If you need help with this file, please <a href="https://www.digitalmarketplace.service.gov.uk" class="govuk-link">contact us via our contact form</a>.'
+  - name: as only text
+    description: 'Attachment with no thumbnail, for insertion into body text, etc'
+    data:
+      contentType: 'application/pdf'
+      fileSize: '21.5 KB'
+      link:
+        text: "Attachment with no thumbnail"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+        classes: 'govuk-body'
+        textOnly: True

--- a/src/digitalmarketplace/components/attachment/macro.njk
+++ b/src/digitalmarketplace/components/attachment/macro.njk
@@ -1,0 +1,3 @@
+{% macro dmAttachment(params) %}
+  {%- include "digitalmarketplace/components/attachment/template.njk" -%}
+{% endmacro %}

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/details/macro.njk" import govukDetails -%}
+
 {% set contentType = params.contentType if params.contentType %}
 {% set abbr %}
   {%- if contentType == 'application/pdf' -%}
@@ -9,6 +11,14 @@
   {%- elseif contentType == 'application/vnd.oasis.opendocument.text' -%}
     <abbr title="OpenDocument Text document" class="dm-attachment__abbr">ODT</abbr>
   {%- endif -%}
+{% endset %}
+
+{% set alternativeFormatDetails %}
+  {% if params.alternativeFormatHtml %}
+    {{ params.alternativeFormatHtml | safe }}
+  {% elseif params.alternativeFormatContactEmail %}
+    If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href="mailto:{{ params.alternativeFormatContactEmail }}" target="_blank" class="govuk-link">{{ params.alternativeFormatContactEmail }}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+  {% endif %}
 {% endset %}
 
 <section class="dm-attachment" data-module="dm-attachment">
@@ -45,5 +55,11 @@
         , <span class="dm-attachment__attribute">{{ params.numberOfPages }} pages</span>
       {% endif -%}
     </p>
+    {% if alternativeFormatDetails %}
+      {{ govukDetails({
+        "summaryText": "Request an accessible format",
+        "html": alternativeFormatDetails
+      })}}
+    {% endif %}
   </div>
 </section>

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -21,45 +21,54 @@
   {% endif %}
 {% endset %}
 
-<section class="dm-attachment" data-module="dm-attachment">
-  <div class="dm-attachment__thumbnail">
-    <a class="govuk-link" href="{{ params.href }}" target="_self" tabindex="-1" aria-hidden="true">
-      {% if contentType == 'application/pdf' %}
-        <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
-          <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
-        </svg>
-      {% elseif contentType == 'text/csv' or contentType == 'application/vnd.oasis.opendocument.spreadsheet' %}
-        <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
-          <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
-          <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
-          <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
-        </svg>
-      {% else %}
-        <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
-          <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
-          <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
-        </svg>
+{% if params.link.textOnly %}
+  <span class="dm-attachment-link{% if params.link.classes %} {{params.link.classes}}{%endif%}">
+    <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
+    ({{ abbr | safe }}
+    {%- if params.fileSize -%}, {{ params.fileSize }}{% endif -%}
+    {%- if params.numberOfPages -%}, {{ params.numberOfPages }} {% if params.numberOfPages == 1 %}page{% else %}pages{% endif %}{% endif -%})
+  </span>
+{% else %}
+  <section class="dm-attachment" data-module="dm-attachment">
+    <div class="dm-attachment__thumbnail">
+      <a class="govuk-link" href="{{ params.link.href }}" target="_self" tabindex="-1" aria-hidden="true">
+        {% if contentType == 'application/pdf' %}
+          <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+            <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
+          </svg>
+        {% elseif contentType == 'text/csv' or contentType == 'application/vnd.oasis.opendocument.spreadsheet' %}
+          <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+            <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
+            <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
+            <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+          </svg>
+        {% else %}
+          <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
+            <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+            <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+          </svg>
+        {% endif %}
+      </a>
+    </div>
+    <div class="dm-attachment__details">
+      <h2 class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
+        <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
+      </h2>
+      <p class="dm-attachment__metadata">
+        <span class="dm-attachment__attribute">{{ abbr | safe }}</span>
+        {%- if params.fileSize -%}
+          , <span class="dm-attachment__attribute">{{ params.fileSize }}</span>
+        {% endif -%}
+        {%- if params.numberOfPages -%}
+          , <span class="dm-attachment__attribute">{{ params.numberOfPages }} {% if params.numberOfPages == 1 %}page{% else %}pages{% endif %}</span>
+        {% endif -%}
+      </p>
+      {% if alternativeFormatDetails %}
+        {{ govukDetails({
+          "summaryText": "Request an accessible format",
+          "html": alternativeFormatDetails
+        })}}
       {% endif %}
-    </a>
-  </div>
-  <div class="dm-attachment__details">
-    <h2 class="dm-attachment__title">
-      <a href="{{ params.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.text }}</a>
-    </h2>
-    <p class="dm-attachment__metadata">
-      <span class="dm-attachment__attribute">{{ abbr | safe }}</span>
-      {%- if params.fileSize -%}
-        , <span class="dm-attachment__attribute">{{ params.fileSize }}</span>
-      {% endif -%}
-      {%- if params.numberOfPages -%}
-        , <span class="dm-attachment__attribute">{{ params.numberOfPages }} pages</span>
-      {% endif -%}
-    </p>
-    {% if alternativeFormatDetails %}
-      {{ govukDetails({
-        "summaryText": "Request an accessible format",
-        "html": alternativeFormatDetails
-      })}}
-    {% endif %}
-  </div>
-</section>
+    </div>
+  </section>
+{% endif %}

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -1,0 +1,49 @@
+{% set contentType = params.contentType if params.contentType %}
+{% set abbr %}
+  {%- if contentType == 'application/pdf' -%}
+    <abbr title="Portable Document Format" class="dm-attachment__abbr">PDF</abbr>
+  {%- elseif contentType == 'text/csv' -%}
+    <abbr title="Comma-separated Values" class="dm-attachment__abbr">CSV</abbr>
+  {%- elseif contentType == 'application/vnd.oasis.opendocument.spreadsheet' -%}
+    <abbr title="OpenDocument Spreadsheet" class="dm-attachment__abbr">ODS</abbr>
+  {%- elseif contentType == 'application/vnd.oasis.opendocument.text' -%}
+    <abbr title="OpenDocument Text document" class="dm-attachment__abbr">ODT</abbr>
+  {%- endif -%}
+{% endset %}
+
+<section class="dm-attachment" data-module="dm-attachment">
+  <div class="dm-attachment__thumbnail">
+    <a class="govuk-link" href="{{ params.href }}" target="_self" tabindex="-1" aria-hidden="true">
+      {% if contentType == 'application/pdf' %}
+        <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+          <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
+        </svg>
+      {% elseif contentType == 'text/csv' or contentType == 'application/vnd.oasis.opendocument.spreadsheet' %}
+        <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+          <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
+          <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
+          <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+        </svg>
+      {% else %}
+        <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
+          <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+          <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+        </svg>
+      {% endif %}
+    </a>
+  </div>
+  <div class="dm-attachment__details">
+    <h2 class="dm-attachment__title">
+      <a href="{{ params.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.text }}</a>
+    </h2>
+    <p class="dm-attachment__metadata">
+      <span class="dm-attachment__attribute">{{ abbr | safe }}</span>
+      {%- if params.fileSize -%}
+        , <span class="dm-attachment__attribute">{{ params.fileSize }}</span>
+      {% endif -%}
+      {%- if params.numberOfPages -%}
+        , <span class="dm-attachment__attribute">{{ params.numberOfPages }} pages</span>
+      {% endif -%}
+    </p>
+  </div>
+</section>

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -10,6 +10,8 @@
     <abbr title="OpenDocument Spreadsheet" class="dm-attachment__abbr">ODS</abbr>
   {%- elseif contentType == 'application/vnd.oasis.opendocument.text' -%}
     <abbr title="OpenDocument Text document" class="dm-attachment__abbr">ODT</abbr>
+  {%- else -%}
+    {{ contentType }}
   {%- endif -%}
 {% endset %}
 
@@ -33,17 +35,17 @@
     <div class="dm-attachment__thumbnail">
       <a class="govuk-link" href="{{ params.link.href }}" target="_self" tabindex="-1" aria-hidden="true">
         {% if contentType == 'application/pdf' %}
-          <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
             <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
           </svg>
         {% elseif contentType == 'text/csv' or contentType == 'application/vnd.oasis.opendocument.spreadsheet' %}
-          <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--csv" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
             <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
             <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
             <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
           </svg>
         {% else %}
-          <svg class="dm-attachment__thumbnail-image" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
+          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--doc" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
             <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
             <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
           </svg>
@@ -54,15 +56,17 @@
       <h2 class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
         <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
       </h2>
-      <p class="dm-attachment__metadata">
-        <span class="dm-attachment__attribute">{{ abbr | safe }}</span>
-        {%- if params.fileSize -%}
-          , <span class="dm-attachment__attribute">{{ params.fileSize }}</span>
-        {% endif -%}
-        {%- if params.numberOfPages -%}
-          , <span class="dm-attachment__attribute">{{ params.numberOfPages }} {% if params.numberOfPages == 1 %}page{% else %}pages{% endif %}</span>
-        {% endif -%}
-      </p>
+      {% if params.contentType %}
+        <p class="dm-attachment__metadata">
+          <span class="dm-attachment__attribute">{{ abbr | safe }}</span>
+          {%- if params.fileSize -%}
+            , <span class="dm-attachment__attribute">{{ params.fileSize }}</span>
+          {% endif -%}
+          {%- if params.numberOfPages -%}
+            , <span class="dm-attachment__attribute">{{ params.numberOfPages }} {% if params.numberOfPages == 1 %}page{% else %}pages{% endif %}</span>
+          {% endif -%}
+        </p>
+      {% endif %}
       {% if alternativeFormatDetails %}
         {{ govukDetails({
           "summaryText": "Request an accessible format",

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers.js')
+
+const examples = getExamples('option-select')
+
+describe('List Input', () => {
+  describe('by default', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples.default)
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples.default, false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a heading for the option select box containing the title', async () => {
+      const $ = render('option-select', examples.default)
+      const title = $('.dm-option-select__title').text().trim()
+
+      expect(title).toEqual('Default')
+    })
+
+    it('renders a container with the ID passed in', async () => {
+      const $ = render('option-select', examples.default)
+      const container = $('#default-options.dm-option-select__container')
+
+      expect(container.length).toBe(1)
+    })
+
+    it('renders a set of checkboxes', async () => {
+      const $ = render('option-select', examples.default)
+      const govukCheckboxes = $('.govuk-checkboxes')
+
+      expect(govukCheckboxes.length).toBe(1)
+
+      const checkboxes = $('.govuk-checkboxes__item')
+
+      expect(checkboxes.length).toBe(5)
+    })
+  })
+
+  describe('when collapsed on load', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with options collapsed'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples['with options collapsed'], false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+  })
+
+  describe('when few options', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with few options'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples['with few options'], false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+  })
+
+  describe('with option pre-checked', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with option pre checked'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('passes basic accessibility tests', async () => {
+      const $ = render('option-select', examples['with option pre checked'], false, false, true)
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a checked checkbox', async () => {
+      const $ = render('option-select', examples['with option pre checked'])
+      const selectedCheckbox = $('#with_checked_value_set-1')
+
+      expect(selectedCheckbox.length).toBe(1)
+      expect(selectedCheckbox.attr('checked')).toBeTruthy()
+    })
+  })
+})

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -6,91 +6,203 @@ const axe = require('../../../../lib/axe-helper')
 
 const { render, getExamples } = require('../../../../lib/jest-helpers.js')
 
-const examples = getExamples('option-select')
+const examples = getExamples('attachment')
 
-describe('List Input', () => {
+describe('Attachment', () => {
   describe('by default', () => {
     it('matches existing snapshot', () => {
-      const $ = render('option-select', examples.default)
+      const $ = render('attachment', examples.default)
       expect($.html()).toMatchSnapshot()
     })
 
     it('passes basic accessibility tests', async () => {
-      const $ = render('option-select', examples.default, false, false, true)
+      const $ = render('attachment', examples.default, false, false, true)
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
-    it('renders a heading for the option select box containing the title', async () => {
-      const $ = render('option-select', examples.default)
-      const title = $('.dm-option-select__title').text().trim()
+    it('renders a thumbnail', async () => {
+      const $ = render('attachment', examples.default)
+      const thumbnail = $('.dm-attachment__thumbnail--doc')
 
-      expect(title).toEqual('Default')
+      expect(thumbnail.length).toBe(1)
     })
 
-    it('renders a container with the ID passed in', async () => {
-      const $ = render('option-select', examples.default)
-      const container = $('#default-options.dm-option-select__container')
+    it('renders a download link with correct text and url', async () => {
+      const $ = render('attachment', examples.default)
+      const link = $('.dm-attachment__link')
 
-      expect(container.length).toBe(1)
+      expect(link.text().trim()).toEqual('Default attachment')
+      expect(link.attr('href')).toEqual('https://digitalmarketplace.service.gov.uk/attachment')
     })
 
-    it('renders a set of checkboxes', async () => {
-      const $ = render('option-select', examples.default)
-      const govukCheckboxes = $('.govuk-checkboxes')
+    it('does not render metadata', async () => {
+      const $ = render('attachment', examples.default)
+      const metadata = $('.dm-attachment__metadata')
 
-      expect(govukCheckboxes.length).toBe(1)
-
-      const checkboxes = $('.govuk-checkboxes__item')
-
-      expect(checkboxes.length).toBe(5)
+      expect(metadata.length).toBe(0)
     })
   })
 
-  describe('when collapsed on load', () => {
+  describe('if spreadsheet', () => {
     it('matches existing snapshot', () => {
-      const $ = render('option-select', examples['with options collapsed'])
+      const $ = render('attachment', examples.spreadsheet)
       expect($.html()).toMatchSnapshot()
     })
 
-    it('passes basic accessibility tests', async () => {
-      const $ = render('option-select', examples['with options collapsed'], false, false, true)
-      const results = await axe($.html())
-      expect(results).toHaveNoViolations()
+    it('renders the correct thumbnail', async () => {
+      const $ = render('attachment', examples.spreadsheet)
+      const thumbnail = $('.dm-attachment__thumbnail--csv')
+
+      expect(thumbnail.length).toBe(1)
+    })
+
+    it('renders the correct filetype and abbreviation', async () => {
+      const $ = render('attachment', examples.spreadsheet)
+      const filetype = $('.dm-attachment__attribute')
+      const abbr = $('.dm-attachment__abbr')
+
+      expect(filetype.text().trim()).toEqual('CSV')
+      expect(abbr.attr('title')).toEqual('Comma-separated Values')
     })
   })
 
-  describe('when few options', () => {
+  describe('if pdf', () => {
     it('matches existing snapshot', () => {
-      const $ = render('option-select', examples['with few options'])
+      const $ = render('attachment', examples.pdf)
       expect($.html()).toMatchSnapshot()
     })
 
-    it('passes basic accessibility tests', async () => {
-      const $ = render('option-select', examples['with few options'], false, false, true)
-      const results = await axe($.html())
-      expect(results).toHaveNoViolations()
+    it('renders the correct thumbnail', async () => {
+      const $ = render('attachment', examples.pdf)
+      const thumbnail = $('.dm-attachment__thumbnail--pdf')
+
+      expect(thumbnail.length).toBe(1)
+    })
+
+    it('renders the correct filetype', async () => {
+      const $ = render('attachment', examples.pdf)
+      const filetype = $('.dm-attachment__attribute')
+      const abbr = $('.dm-attachment__abbr')
+
+      expect(filetype.text().trim()).toEqual('PDF')
+      expect(abbr.attr('title')).toEqual('Portable Document Format')
     })
   })
 
-  describe('with option pre-checked', () => {
+  describe('if unknown filetype', () => {
     it('matches existing snapshot', () => {
-      const $ = render('option-select', examples['with option pre checked'])
+      const $ = render('attachment', examples['unknown filetype'])
       expect($.html()).toMatchSnapshot()
     })
 
-    it('passes basic accessibility tests', async () => {
-      const $ = render('option-select', examples['with option pre checked'], false, false, true)
-      const results = await axe($.html())
-      expect(results).toHaveNoViolations()
+    it('renders a generic thumbnail', async () => {
+      const $ = render('attachment', examples['unknown filetype'])
+      const thumbnail = $('.dm-attachment__thumbnail--doc')
+
+      expect(thumbnail.length).toBe(1)
     })
 
-    it('renders a checked checkbox', async () => {
-      const $ = render('option-select', examples['with option pre checked'])
-      const selectedCheckbox = $('#with_checked_value_set-1')
+    it('renders the raw filetype', async () => {
+      const $ = render('attachment', examples['unknown filetype'])
+      const filetype = $('.dm-attachment__attribute')
 
-      expect(selectedCheckbox.length).toBe(1)
-      expect(selectedCheckbox.attr('checked')).toBeTruthy()
+      expect(filetype.text().trim()).toEqual('txt')
+    })
+  })
+
+  describe('with file size', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with file size'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders the file size', async () => {
+      const $ = render('attachment', examples['with file size'])
+      const attributes = $('.dm-attachment__attribute')
+      expect(attributes.length).toBe(2)
+      expect($(attributes[1]).text().trim()).toEqual('21.5 KB')
+    })
+  })
+
+  describe('with page count', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with page count'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders the page count', async () => {
+      const $ = render('attachment', examples['with page count'])
+      const attributes = $('.dm-attachment__attribute')
+      expect(attributes.length).toBe(2)
+      expect($(attributes[1]).text().trim()).toEqual('12 pages')
+    })
+  })
+
+  describe('with alternative format contact email', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with alternative format contact email'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders a details component', async () => {
+      const $ = render('attachment', examples['with alternative format contact email'])
+      const details = $('.govuk-details')
+      expect(details.length).toBe(1)
+
+      const summary = $('.govuk-details__summary')
+      expect(summary.text().trim()).toEqual('Request an accessible format')
+
+      const detailText = $('.govuk-details__text')
+      expect(detailText.text()).toContain(examples['with alternative format contact email'].alternativeFormatContactEmail)
+    })
+  })
+
+  describe('with alternative format HTML', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['with alternative format HTML'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders a details component', async () => {
+      const $ = render('attachment', examples['with alternative format HTML'])
+      const details = $('.govuk-details')
+      expect(details.length).toBe(1)
+
+      const summary = $('.govuk-details__summary')
+      expect(summary.text().trim()).toEqual('Request an accessible format')
+
+      const detailText = $('.govuk-details__text')
+      expect(detailText.html().trim()).toEqual(examples['with alternative format HTML'].alternativeFormatHtml)
+    })
+  })
+
+  describe('as text only', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('option-select', examples['as only text'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('does not render thumbnail', async () => {
+      const $ = render('attachment', examples['as only text'])
+      const thumbnail = $('.dm-attachment__thumbnail')
+
+      expect(thumbnail.length).toBe(0)
+    })
+
+    it('renders class attribute', async () => {
+      const $ = render('attachment', examples['as only text'])
+      const link = $('.' + examples['as only text'].link.classes)
+
+      expect(link.length).toBe(1)
+    })
+
+    it('parenthesizes attributes', async () => {
+      const $ = render('attachment', examples['as only text'])
+      const linkText = $('.dm-attachment-link').text().trim()
+
+      expect(linkText).toContain('Attachment with no thumbnail')
+      expect(linkText).toContain('(PDF, 21.5 KB)')
     })
   })
 })


### PR DESCRIPTION
https://trello.com/c/jUpsvkxU/243-2-add-attachment-component-to-digital-marketplace-govuk-frontend

The component requires link information (title and href), but also supports optional information:

* file type
* file size
* number of pages
* contact email for alternative format
* custom html for alternative format

It is based on the [GOVUK Publishing Components Attachment](https://components.publishing.service.gov.uk/component-guide/attachment)

I've implemented the thumbnail by accounting explicitly for PDFs and CSVs which should cover the bulk of our documents. There is also a default thumbnail for any other doc types.

It's also possible to exclude the thumbnail altogether, for cases where we want to insert this component as text in a list or other contexts. In this case, the component renders similarly to the [GOVUK Publishing components Attachment Link](https://components.publishing.service.gov.uk/component-guide/attachment_link).