### PR TITLE
Ignore no-var linting rule

### DIFF
--- a/src/digitalmarketplace/all.js
+++ b/src/digitalmarketplace/all.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 import './vendor/polyfills/NodeList/prototype/forEach'
 import CookieBanner from './components/cookie-banner/cookie-banner'
 import CookieSettings from './components/cookie-settings/cookie-settings'

--- a/src/digitalmarketplace/components/analytics/analytics.js
+++ b/src/digitalmarketplace/components/analytics/analytics.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 import stripPII from './pii'
 
 // Stripped-down wrapper for Google Analytics, based on:

--- a/src/digitalmarketplace/components/analytics/init.js
+++ b/src/digitalmarketplace/components/analytics/init.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 import * as PageAnalytics from './analytics'
 
 window.DMGOVUKFrontend = window.DMGOVUKFrontend || {}

--- a/src/digitalmarketplace/components/analytics/pii.js
+++ b/src/digitalmarketplace/components/analytics/pii.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable no-var */
 // Based on https://github.com/alphagov/static/pull/1863
 const EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
 

--- a/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
+++ b/src/digitalmarketplace/components/cookie-banner/cookie-banner.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 import { getCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
 import InitialiseAnalytics from '../analytics/init'
 

--- a/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
+++ b/src/digitalmarketplace/components/cookie-settings/cookie-settings.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 // Javascript code to support the Cookie Settings page
 import { getConsentCookie, setConsentCookie } from '../../helpers/cookie/cookie-functions'
 import InitialiseAnalytics from '../analytics/init'

--- a/src/digitalmarketplace/components/list-input/list-input.js
+++ b/src/digitalmarketplace/components/list-input/list-input.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 var getSibling = function (direction, elem, selector) {
   // Get the next sibling element
   var sibling = (direction === 'next') ? elem.nextElementSibling : elem.previousElementSibling

--- a/src/digitalmarketplace/components/option-select/option-select.js
+++ b/src/digitalmarketplace/components/option-select/option-select.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 function OptionSelect ($module) {
   this.$optionSelect = $module
   this.$options = this.$optionSelect.querySelectorAll("input[type='checkbox']")

--- a/src/digitalmarketplace/components/search-box/search-box.js
+++ b/src/digitalmarketplace/components/search-box/search-box.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 function SearchBox ($module) {
   this.$module = $module
   this.toggleTarget = this.$module.querySelector('.js-class-toggle')

--- a/src/digitalmarketplace/helpers/cookie/cookie-functions.js
+++ b/src/digitalmarketplace/helpers/cookie/cookie-functions.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 // used by the cookie banner component
 const DEFAULT_COOKIE_CONSENT = {
   analytics: false


### PR DESCRIPTION
This fixes the warnings (for standard 17+, errors) we get because of our use of "var" instead of let/const.

standard doesn't offer an obvious way to ignore a specific rule in the config, and I'd prefer not to go down the route of defining a custom eslint config since that kind of defeats the purpose of standard.

Ignoring its rules also kind of defeats that purpose, but at least we're aware of this one specific case!

We could look into moving completely to ES6 or just using let/const in place of the vars, but this will come with effort, so for now this will do.