### PR TITLE
Adjust spacing for option select header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ See below for Changelog examples.
 
   ([PR #149](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/149))
 
+🔧 Fixes:
+
+- Option select header spacing adjustments [PR #219](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/219)
+
+
 ## 2.6.0
 
 🆕 New features:

--- a/src/digitalmarketplace/components/option-select/_option-select.scss
+++ b/src/digitalmarketplace/components/option-select/_option-select.scss
@@ -76,7 +76,7 @@
   .dm-option-select__icon {
     display: none;
     position: absolute;
-    top: 0;
+    top: 4px;
     left: 9px;
     width: 30px;
     height: 40px;
@@ -107,6 +107,7 @@
     .dm-option-select__heading {
       position: relative;
       padding: 10px 8px 5px 43px;
+      margin: 0;
     }
   
     [aria-expanded="true"] ~ .dm-option-select__icon--up {


### PR DESCRIPTION
With the upgrade to govuk-frontend 3, we need to account for spacing/font differences in the `<h2>` tag.