### PR TITLE
Replace standard with standardx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17441,6 +17441,15 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "standardx": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/standardx/-/standardx-7.0.0.tgz",
+      "integrity": "sha512-Uh2LIWyMD0pMFn+zoAS52dforkE8MUWP6hK48iQhiohTC5DRqBgTdXdJbhSGyjamRxCfETBdfvJ7hvtme2M3jg==",
+      "requires": {
+        "standard": "^16.0.1",
+        "standard-engine": "^14.0.1"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "gulp dev --gulpfile 'app/gulpfile.js'",
     "heroku": "node app/start.js",
-    "test": "standard && gulp compile && jest",
+    "test": "standardx && gulp compile && jest",
     "build": "gulp build --silent",
     "release": "./bin/release.sh",
     "release:dry-run": "npm run release -- --dry-run",
@@ -23,7 +23,7 @@
     "gulp": "^4.0.2",
     "gulp-postcss": "^8.0.0",
     "node-emoji": "^1.10.0",
-    "standard": "^16.0.2"
+    "standardx": "^7.0.0"
   },
   "jest": {
     "preset": "jest-puppeteer",
@@ -45,7 +45,7 @@
     "ie 11",
     "iOS >= 9"
   ],
-  "standard": {
+  "standardx": {
     "env": [
       "jest"
     ],
@@ -61,6 +61,11 @@
       "/node_modules/**/*",
       "/src/digitalmarketplace/vendor/**/*"
     ]
+  },
+  "eslintConfig": {
+    "rules": {
+      "no-var": 0
+    }
   },
   "devDependencies": {
     "autoprefixer": "^9.8.6",


### PR DESCRIPTION
### What
This PR changes our use of [standard](https://github.com/standard/standard) to [standardx](https://github.com/standard/standardx) for JS linting. This is to allow the editing of rules, specifically disabling the [no-var](https://eslint.org/docs/rules/no-var) rule.

### Why
Our components currently use `var` across the board to provide limited support to older browsers. While we'd prefer to update these to ES2015+, this is not a small amount of work. However, now that standard requires `let` or `const` over `var`, we are producing consistent warnings in our tests that will graduate to errors from standard 17+.

We're following the approach taken by govuk_publishing_components (https://github.com/alphagov/govuk_publishing_components/pull/1785) since it seems simple and sensible.