### PR TITLE
Attachment component enhancements

### DIFF
--- a/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
@@ -179,7 +179,7 @@ exports[`Attachment with description matches existing snapshot 1`] = `
       <h2 class=\\"dm-attachment__title\\">
         <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with description</a>
       </h2>
-        <p class=\\"govuk-hint\\">This is the agreement you signed.</p>
+        <div class=\\"govuk-hint\\">This is the agreement you signed.</div>
         <p class=\\"dm-attachment__metadata\\">
           <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span></p>
     </div>
@@ -202,6 +202,27 @@ exports[`Attachment with file size matches existing snapshot 1`] = `
       </h2>
         <p class=\\"dm-attachment__metadata\\">
           <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span>, <span class=\\"dm-attachment__attribute\\">21.5 KB</span>
+</p>
+    </div>
+  </section>
+</body></html>"
+`;
+
+exports[`Attachment with last updated matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with last updated</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span>, <span class=\\"dm-attachment__attribute\\">Last updated: <time datetime=\\"2020-01-01\\">New year&apos;s day</time></span>
 </p>
     </div>
   </section>

--- a/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
@@ -146,6 +146,26 @@ exports[`Attachment with alternative format contact email matches existing snaps
 </body></html>"
 `;
 
+exports[`Attachment with custom heading level matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h3 class=\\"dm-attachment__title\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with custom heading level</a>
+      </h3>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span></p>
+    </div>
+  </section>
+</body></html>"
+`;
+
 exports[`Attachment with description matches existing snapshot 1`] = `
 "<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
     <div class=\\"dm-attachment__thumbnail\\">

--- a/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
@@ -249,3 +249,23 @@ exports[`Attachment with page count matches existing snapshot 1`] = `
   </section>
 </body></html>"
 `;
+
+exports[`Attachment with small thumbnail matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail dm-attachment__thumbnail--small\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf dm-attachment__thumbnail-image--small\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title govuk-!-font-size-19\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\">Attachment with small thumbnail</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span></p>
+    </div>
+  </section>
+</body></html>"
+`;

--- a/src/digitalmarketplace/components/attachment/_attachment.scss
+++ b/src/digitalmarketplace/components/attachment/_attachment.scss
@@ -1,5 +1,7 @@
 $thumbnail-width: 99px;
+$thumbnail-small-width: 30px;
 $thumbnail-height: 140px;
+$thumbnail-small-height: 43px;
 $thumbnail-border-width: 5px;
 $thumbnail-background: govuk-colour("white");
 $thumbnail-border-colour: rgba(11, 12, 12, .1);
@@ -25,6 +27,17 @@ $thumbnail-icon-border-colour: $govuk-border-colour;
   padding: $thumbnail-border-width;
   float: left;
 }
+.dm-attachment__thumbnail--small {
+  margin-right: govuk-spacing(2);
+  margin-bottom: govuk-spacing(0);
+  + div.dm-attachment__details {
+    padding-left: 60px;
+    .dm-attachment__title {
+      @include govuk-font($size: 19);
+      margin-bottom: govuk-spacing(1);
+    }
+  }
+}
 
 .dm-attachment__thumbnail-image {
   display: block;
@@ -37,6 +50,10 @@ $thumbnail-icon-border-colour: $govuk-border-colour;
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
   fill: $thumbnail-icon-border-colour;
   stroke: $thumbnail-icon-border-colour;
+}
+.dm-attachment__thumbnail-image--small {
+  max-width: $thumbnail-small-width;
+  height: $thumbnail-small-height;
 }
 
 .dm-attachment__details {

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -27,6 +27,18 @@ params:
 - name: numberOfPages
   type: integer
   description: Number of pages in the attached document
+- name: lastUpdated
+  type: object
+  description: When the document was last updated
+  params:
+  - name: datetime
+    type: string
+    required: true
+    description: The datetime string
+  - name: text
+    type: string
+    required: true
+    description: The time string
 - name: alternativeFormatHtml
   type: string
   description: Information on how to request an accessible format.
@@ -85,6 +97,16 @@ examples:
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       fileSize: '21.5 KB'
+  - name: with last updated
+    description: 'Attachment with last updated'
+    data:
+      link:
+        text: "Attachment with last updated"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      lastUpdated:
+        datetime: '2020-01-01'
+        text: "New year's day"
   - name: with page count
     description: 'Attachment with page count'
     data:

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -60,6 +60,9 @@ params:
 - name: headingLevel
   type: integer
   description: 1 - 6. Used to set the heading level of the download link. Defaults to 2.
+- name: thumbnailSize
+  type: string
+  description: Set to "small" to reduce thumbnail size. Defaults to a larger size.
 
 examples:
   - name: default
@@ -158,3 +161,12 @@ examples:
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       headingLevel: 3
+  - name: with small thumbnail
+    description: 'Attachment with small thumbnail'
+    data:
+      link:
+        classes: 'govuk-!-font-size-19'
+        text: "Attachment with small thumbnail"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      thumbnailSize: 'small'

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -36,6 +36,9 @@ params:
 - name: description
   type: string
   description: Used to provide a description of the document
+- name: headingLevel
+  type: integer
+  description: 1 - 6. Used to set the heading level of the download link. Defaults to 2.
 
 examples:
   - name: default
@@ -115,3 +118,11 @@ examples:
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       description: 'This is the agreement you signed.'
+  - name: with custom heading level
+    description: 'Attachment with custom heading level'
+    data:
+      link:
+        text: "Attachment with custom heading level"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+      contentType: 'application/pdf'
+      headingLevel: 3

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -34,8 +34,17 @@ params:
   type: string
   description: Used to provide an email to request an accessible format
 - name: description
-  type: string
+  type: object
   description: Used to provide a description of the document
+  params:
+  - name: html
+    type: string
+    required: true
+    description: HTML for the description. Either this or text must be provided.
+  - name: text
+    type: string
+    required: true
+    description: Text for the description. Either this or html must be provided.
 - name: headingLevel
   type: integer
   description: 1 - 6. Used to set the heading level of the download link. Defaults to 2.
@@ -117,7 +126,8 @@ examples:
         text: "Attachment with description"
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
-      description: 'This is the agreement you signed.'
+      description: 
+        text: 'This is the agreement you signed.'
   - name: with custom heading level
     description: 'Attachment with custom heading level'
     data:

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -57,9 +57,9 @@ params:
     type: string
     required: true
     description: Text for the description. Either this or html must be provided.
-- name: headingLevel
-  type: integer
-  description: 1 - 6. Used to set the heading level of the download link. Defaults to 2.
+- name: headingTag
+  type: string
+  description: Used to set the tag of the download link wrapper. Defaults to h2.
 - name: thumbnailSize
   type: string
   description: Set to "small" to reduce thumbnail size. Defaults to a larger size.
@@ -160,7 +160,7 @@ examples:
         text: "Attachment with custom heading level"
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
-      headingLevel: 3
+      headingTag: 'h3'
   - name: with small thumbnail
     description: 'Attachment with small thumbnail'
     data:

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -56,9 +56,9 @@
       </a>
     </div>
     <div class="dm-attachment__details">
-      <h{% if params.headingLevel %}{{params.headingLevel}}{% else %}2{%endif%} class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
+      <{% if params.headingTag %}{{params.headingTag}}{% else %}h2{%endif%} class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
         <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
-      </h{% if params.headingLevel %}{{params.headingLevel}}{% else %}2{%endif%}>
+      </{% if params.headingTag %}{{params.headingTag}}{% else %}h2{%endif%}>
       {% if params.description %}
         <div class="govuk-hint">{% if params.description.html %}{{ params.description.html | safe }}{% else %}{{ params.description.text }}{% endif %}</div>
       {% endif %}

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -15,6 +15,9 @@
   {%- endif -%}
 {% endset %}
 
+{% set thumbnailClasses = " dm-attachment__thumbnail--small" if params.thumbnailSize == "small" %}
+{% set thumbnailImageClasses = " dm-attachment__thumbnail-image--small" if params.thumbnailSize == "small" %}
+
 {% set alternativeFormatDetails %}
   {% if params.alternativeFormatHtml %}
     {{ params.alternativeFormatHtml | safe }}
@@ -32,20 +35,20 @@
   </span>
 {% else %}
   <section class="dm-attachment" data-module="dm-attachment">
-    <div class="dm-attachment__thumbnail">
+    <div class="dm-attachment__thumbnail{{ thumbnailClasses }}">
       <a class="govuk-link" href="{{ params.link.href }}" target="_self" tabindex="-1" aria-hidden="true">
         {% if contentType == 'application/pdf' %}
-          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf{{ thumbnailImageClasses }}" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
             <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
           </svg>
         {% elseif contentType == 'text/csv' or contentType == 'application/vnd.oasis.opendocument.spreadsheet' %}
-          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--csv" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--csv{{ thumbnailImageClasses }}" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
             <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
             <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
             <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
           </svg>
         {% else %}
-          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--doc" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
+          <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--doc{{ thumbnailImageClasses }}" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
             <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
             <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
           </svg>

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -53,9 +53,9 @@
       </a>
     </div>
     <div class="dm-attachment__details">
-      <h2 class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
+      <h{% if params.headingLevel %}{{params.headingLevel}}{% else %}2{%endif%} class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
         <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
-      </h2>
+      </h{% if params.headingLevel %}{{params.headingLevel}}{% else %}2{%endif%}>
       {% if params.description %}
         <p class="govuk-hint">{{ params.description }}</p>
       {% endif %}

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -18,6 +18,7 @@
 {% set thumbnailClasses = " dm-attachment__thumbnail--small" if params.thumbnailSize == "small" %}
 {% set thumbnailImageClasses = " dm-attachment__thumbnail-image--small" if params.thumbnailSize == "small" %}
 
+{% set hasAlternativeFormat = params.alternativeFormatHtml is defined or params.alternativeFormatContactEmail is defined %}
 {% set alternativeFormatDetails %}
   {% if params.alternativeFormatHtml %}
     {{ params.alternativeFormatHtml | safe }}
@@ -76,7 +77,7 @@
           {% endif -%}
         </p>
       {% endif %}
-      {% if alternativeFormatDetails %}
+      {% if hasAlternativeFormat %}
         {{ govukDetails({
           "summaryText": "Request an accessible format",
           "html": alternativeFormatDetails

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -68,6 +68,9 @@
           {%- if params.numberOfPages -%}
             , <span class="dm-attachment__attribute">{{ params.numberOfPages }} {% if params.numberOfPages == 1 %}page{% else %}pages{% endif %}</span>
           {% endif -%}
+          {%- if params.lastUpdated -%}
+            , <span class="dm-attachment__attribute">Last updated: <time datetime="{{ params.lastUpdated.datetime }}">{{ params.lastUpdated.text }}</time></span>
+          {% endif -%}
         </p>
       {% endif %}
       {% if alternativeFormatDetails %}

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -57,7 +57,7 @@
         <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
       </h{% if params.headingLevel %}{{params.headingLevel}}{% else %}2{%endif%}>
       {% if params.description %}
-        <p class="govuk-hint">{{ params.description }}</p>
+        <div class="govuk-hint">{% if params.description.html %}{{ params.description.html | safe }}{% else %}{{ params.description.text }}{% endif %}</div>
       {% endif %}
       {% if params.contentType %}
         <p class="dm-attachment__metadata">

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -219,4 +219,19 @@ describe('Attachment', () => {
       expect(description.text().trim()).toEqual('This is the agreement you signed.')
     })
   })
+
+  describe('with custom heading level', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with custom heading level'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders a description', async () => {
+      const $ = render('attachment', examples['with custom heading level'])
+      console.log($.html())
+      const heading = $('h3')
+
+      expect(heading.text().trim()).toEqual('Attachment with custom heading level')
+    })
+  })
 })

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -233,4 +233,19 @@ describe('Attachment', () => {
       expect(heading.text().trim()).toEqual('Attachment with custom heading level')
     })
   })
+
+  describe('with last updated', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with last updated'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders a time tag', async () => {
+      const $ = render('attachment', examples['with last updated'])
+      const time = $('time')
+
+      expect(time.text().trim()).toEqual("New year's day")
+      expect(time.attr('datetime')).toEqual('2020-01-01')
+    })
+  })
 })

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -228,7 +228,6 @@ describe('Attachment', () => {
 
     it('renders a description', async () => {
       const $ = render('attachment', examples['with custom heading level'])
-      console.log($.html())
       const heading = $('h3')
 
       expect(heading.text().trim()).toEqual('Attachment with custom heading level')

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -26,6 +26,9 @@ describe('Attachment', () => {
       const thumbnail = $('.dm-attachment__thumbnail--doc')
 
       expect(thumbnail.length).toBe(1)
+
+      const thumbnailSmall = $('dm-attachment__thumbnail--small')
+      expect(thumbnailSmall.length).toBe(0)
     })
 
     it('renders a download link with correct text and url', async () => {
@@ -246,6 +249,19 @@ describe('Attachment', () => {
 
       expect(time.text().trim()).toEqual("New year's day")
       expect(time.attr('datetime')).toEqual('2020-01-01')
+    })
+  })
+
+  describe('with small thumbnail', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with small thumbnail'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('renders a small thumbnail', async () => {
+      const $ = render('attachment', examples['with small thumbnail'])
+      const thumbnail = $('.dm-attachment__thumbnail--small')
+      expect(thumbnail.length).toBe(1)
     })
   })
 })


### PR DESCRIPTION
https://trello.com/c/tUd7Ck2w/275-5-replace-document-links-with-attachment-component-in-frontend-apps

This PR is a result of testing the Attachment component in real-life settings.

It adds the following enhancements:

* A custom tag for the link text - this defaults to `h2`
* Allows the "description" property to be either text or html
* Adds a "last updated" property to the available metadata properties
* Adds a slimline version of the component with a small thumbnail, for use in environments like table rows where space is at more of a premium. It's also still possible to use the text-only version of the component, but that's probably more suitable for use within bodies of text.
* Fixes a bug where the accessible format request details component would display even if no details had been specified.