### PR TITLE
Release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 See below for Changelog examples.
 
+## 2.8.0
+
+🆕 New features:
+
+  - Attachments can have custom tags for link text [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)
+  - Adds a "last updated" property to attachments [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)
+  - Adds a slimline version of the attachment with a smaller thumbnail [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)
+
+🔧 Fixes:
+
+  - Attachment accessible format details now do not display if not set [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)
+
 ## 2.7.0
 
 🆕 New features:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
🆕 New features:

  - Attachments can have custom tags for link text [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)
  - Adds a "last updated" property to attachments [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)
  - Adds a slimline version of the attachment with a smaller thumbnail [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)

🔧 Fixes:

  - Attachment accessible format details now do not display if not set [PR #233](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/233)