### PR TITLE
Add attributes to attachment link

### DIFF
--- a/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
@@ -229,6 +229,26 @@ exports[`Attachment with last updated matches existing snapshot 1`] = `
 </body></html>"
 `;
 
+exports[`Attachment with link attributes matches existing snapshot 1`] = `
+"<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
+    <div class=\\"dm-attachment__thumbnail\\">
+      <a class=\\"govuk-link\\" href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" target=\\"_self\\" tabindex=\\"-1\\" aria-hidden=\\"true\\" key1=\\"value1\\" key2=\\"value2\\">
+          <svg class=\\"dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf\\" version=\\"1.1\\" viewBox=\\"0 0 99 140\\" width=\\"99\\" height=\\"140\\" aria-hidden=\\"true\\">
+            <path d=\\"M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z\\" stroke-width=\\"0\\"/>
+          </svg>
+      </a>
+    </div>
+    <div class=\\"dm-attachment__details\\">
+      <h2 class=\\"dm-attachment__title govuk-!-font-size-19\\">
+        <a href=\\"https://digitalmarketplace.service.gov.uk/attachment.pdf\\" class=\\"govuk-link dm-attachment__link\\" target=\\"_self\\" key1=\\"value1\\" key2=\\"value2\\">Attachment with link attributes</a>
+      </h2>
+        <p class=\\"dm-attachment__metadata\\">
+          <span class=\\"dm-attachment__attribute\\"><abbr title=\\"Portable Document Format\\" class=\\"dm-attachment__abbr\\">PDF</abbr></span></p>
+    </div>
+  </section>
+</body></html>"
+`;
+
 exports[`Attachment with page count matches existing snapshot 1`] = `
 "<html><head></head><body><section class=\\"dm-attachment\\" data-module=\\"dm-attachment\\">
     <div class=\\"dm-attachment__thumbnail\\">

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -18,6 +18,9 @@ params:
   - name: classes
     type: string
     description: Classes to apply to the link
+  - name: attributes
+    type: object
+    description: HTML attributes to add to the link
 - name: contentType
   type: string
   description: The filetype of the attached document (eg - 'text/csv')
@@ -170,3 +173,14 @@ examples:
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
       thumbnailSize: 'small'
+  - name: with link attributes
+    description: 'Attachment with link attributes'
+    data:
+      link:
+        classes: 'govuk-!-font-size-19'
+        text: "Attachment with link attributes"
+        href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
+        attributes: 
+          key1: "value1"
+          key2: "value2"
+      contentType: 'application/pdf'

--- a/src/digitalmarketplace/components/attachment/template.njk
+++ b/src/digitalmarketplace/components/attachment/template.njk
@@ -29,7 +29,12 @@
 
 {% if params.link.textOnly %}
   <span class="dm-attachment-link{% if params.link.classes %} {{params.link.classes}}{%endif%}">
-    <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
+    <a
+      href="{{ params.link.href }}"
+      class="govuk-link dm-attachment__link"
+      target="_self"
+      {%- for attribute in (params.link.attributes | default({}) | dictsort) %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
+    >{{ params.link.text }}</a>
     ({{ abbr | safe }}
     {%- if params.fileSize -%}, {{ params.fileSize }}{% endif -%}
     {%- if params.numberOfPages -%}, {{ params.numberOfPages }} {% if params.numberOfPages == 1 %}page{% else %}pages{% endif %}{% endif -%})
@@ -37,7 +42,14 @@
 {% else %}
   <section class="dm-attachment" data-module="dm-attachment">
     <div class="dm-attachment__thumbnail{{ thumbnailClasses }}">
-      <a class="govuk-link" href="{{ params.link.href }}" target="_self" tabindex="-1" aria-hidden="true">
+      <a
+        class="govuk-link"
+        href="{{ params.link.href }}"
+        target="_self"
+        tabindex="-1"
+        aria-hidden="true"
+        {%- for attribute in (params.link.attributes | default({}) | dictsort) %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
+      >
         {% if contentType == 'application/pdf' %}
           <svg class="dm-attachment__thumbnail-image dm-attachment__thumbnail--pdf{{ thumbnailImageClasses }}" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
             <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
@@ -58,7 +70,12 @@
     </div>
     <div class="dm-attachment__details">
       <{% if params.headingTag %}{{params.headingTag}}{% else %}h2{%endif%} class="dm-attachment__title{% if params.link.classes %} {{params.link.classes}}{%endif%}">
-        <a href="{{ params.link.href }}" class="govuk-link dm-attachment__link" target="_self">{{ params.link.text }}</a>
+        <a 
+          href="{{ params.link.href }}"
+          class="govuk-link dm-attachment__link"
+          target="_self"
+          {%- for attribute in (params.link.attributes | default({}) | dictsort) %} {{attribute[0]}}="{{attribute[1]}}" {%- endfor %}
+        >{{ params.link.text }}</a>
       </{% if params.headingTag %}{{params.headingTag}}{% else %}h2{%endif%}>
       {% if params.description %}
         <div class="govuk-hint">{% if params.description.html %}{{ params.description.html | safe }}{% else %}{{ params.description.text }}{% endif %}</div>

--- a/src/digitalmarketplace/components/attachment/template.test.js
+++ b/src/digitalmarketplace/components/attachment/template.test.js
@@ -264,4 +264,23 @@ describe('Attachment', () => {
       expect(thumbnail.length).toBe(1)
     })
   })
+
+  describe('with link attributes', () => {
+    it('matches existing snapshot', () => {
+      const $ = render('attachment', examples['with link attributes'])
+      expect($.html()).toMatchSnapshot()
+    })
+
+    it('applies attributes to link', async () => {
+      const $ = render('attachment', examples['with link attributes'])
+      const $component = $('.dm-attachment')
+      const links = $component.find('.govuk-link')
+      expect(links.length).toBe(2)
+
+      for (let i = 0; i < links.length; i++) {
+        expect(links[i].attribs.key1).toEqual('value1')
+        expect(links[i].attribs.key2).toEqual('value2')
+      }
+    })
+  })
 })


### PR DESCRIPTION
One of our document links on the Buyer Frontend has an analytics event attached to it, and so needs some extra attributes. It's not difficult to see this being the case for other documents as well.

I missed this for the previous release, annoyingly, but it should also be released so it can be used on the Buyer Frontend app.