### PR TITLE
Change first input in list input to have id without suffix

### DIFF
--- a/src/digitalmarketplace/components/list-input/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/list-input/__snapshots__/template.test.js.snap
@@ -11,10 +11,10 @@ exports[`List Input by default matches existing snapshot 1`] = `
   <div class=\\"dm-list-input__item-container\\" role=\\"region\\" aria-live=\\"assertive\\">
 <div class=\\"dm-list-input__item dm-list-input__item--visible\\"><div class=\\"dm-list-input__row\\">
           <div class=\\"govuk-form-group dm-list-input__form-group\\">
-    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-1\\">
+    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list\\">
       <span class=\\"govuk-visually-hidden\\">What requirements are essential to carry out the work?. Number </span><span class=\\"dm-list-input__counter\\">1</span>.
     </label>
-  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-1\\" name=\\"requirements\\" type=\\"text\\"></div>
+  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list\\" name=\\"requirements\\" type=\\"text\\"></div>
           <button type=\\"button\\" class=\\"govuk-button govuk-button--secondary dm-list-input__item-remove dm-list-input__item-remove--hidden\\" data-module=\\"govuk-button\\">
   Remove <span class=\\"govuk-visually-hidden\\">entry number <span class=\\"dm-list-input__counter\\">1</span></span>
 </button>
@@ -140,10 +140,10 @@ exports[`List Input when it is optional matches existing snapshot 1`] = `
   <div class=\\"dm-list-input__item-container\\" role=\\"region\\" aria-live=\\"assertive\\">
 <div class=\\"dm-list-input__item dm-list-input__item--visible\\"><div class=\\"dm-list-input__row\\">
           <div class=\\"govuk-form-group dm-list-input__form-group\\">
-    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-2-1\\">
+    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-2\\">
       <span class=\\"govuk-visually-hidden\\">What requirements are essential to carry out the work?. Number </span><span class=\\"dm-list-input__counter\\">1</span>.
     </label>
-  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-2-1\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
+  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-2\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
           <button type=\\"button\\" class=\\"govuk-button govuk-button--secondary dm-list-input__item-remove dm-list-input__item-remove--hidden\\" data-module=\\"govuk-button\\">
   Remove <span class=\\"govuk-visually-hidden\\">entry number <span class=\\"dm-list-input__counter\\">1</span></span>
 </button>
@@ -195,10 +195,10 @@ exports[`List Input with errors with component-level error matches existing snap
   <div class=\\"dm-list-input__item-container\\" role=\\"region\\" aria-live=\\"assertive\\">
 <div class=\\"dm-list-input__item dm-list-input__item--visible\\"><div class=\\"dm-list-input__row\\">
           <div class=\\"govuk-form-group dm-list-input__form-group\\">
-    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-2-1\\">
+    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-2\\">
       <span class=\\"govuk-visually-hidden\\">What requirements are essential to carry out the work?. Number </span><span class=\\"dm-list-input__counter\\">1</span>.
     </label>
-  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-2-1\\" name=\\"requirements\\" type=\\"text\\"></div>
+  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-2\\" name=\\"requirements\\" type=\\"text\\"></div>
           <button type=\\"button\\" class=\\"govuk-button govuk-button--secondary dm-list-input__item-remove dm-list-input__item-remove--hidden\\" data-module=\\"govuk-button\\">
   Remove <span class=\\"govuk-visually-hidden\\">entry number <span class=\\"dm-list-input__counter\\">1</span></span>
 </button>
@@ -250,10 +250,10 @@ exports[`List Input with errors with input-level errors matches existing snapsho
   <div class=\\"dm-list-input__item-container\\" role=\\"region\\" aria-live=\\"assertive\\">
 <div class=\\"dm-list-input__item dm-list-input__item--visible\\"><div class=\\"dm-list-input__row\\">
           <div class=\\"govuk-form-group dm-list-input__form-group\\">
-    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-3-1\\">
+    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-3\\">
       <span class=\\"govuk-visually-hidden\\">What requirements are essential to carry out the work?. Number </span><span class=\\"dm-list-input__counter\\">1</span>.
     </label>
-  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-3-1\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
+  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-3\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
           <button type=\\"button\\" class=\\"govuk-button govuk-button--secondary dm-list-input__item-remove dm-list-input__item-remove--hidden\\" data-module=\\"govuk-button\\">
   Remove <span class=\\"govuk-visually-hidden\\">entry number <span class=\\"dm-list-input__counter\\">1</span></span>
 </button>
@@ -308,10 +308,10 @@ exports[`List Input with existing values matches existing snapshot 1`] = `
   <div class=\\"dm-list-input__item-container\\" role=\\"region\\" aria-live=\\"assertive\\">
 <div class=\\"dm-list-input__item dm-list-input__item--visible\\"><div class=\\"dm-list-input__row\\">
           <div class=\\"govuk-form-group dm-list-input__form-group\\">
-    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-1\\">
+    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list\\">
       <span class=\\"govuk-visually-hidden\\">What requirements are essential to carry out the work?. Number </span><span class=\\"dm-list-input__counter\\">1</span>.
     </label>
-  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-1\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
+  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
           <button type=\\"button\\" class=\\"govuk-button govuk-button--secondary dm-list-input__item-remove dm-list-input__item-remove--hidden\\" data-module=\\"govuk-button\\">
   Remove <span class=\\"govuk-visually-hidden\\">entry number <span class=\\"dm-list-input__counter\\">1</span></span>
 </button>
@@ -440,10 +440,10 @@ exports[`List Input with hint matches existing snapshot 1`] = `
   <div class=\\"dm-list-input__item-container\\" role=\\"region\\" aria-live=\\"assertive\\">
 <div class=\\"dm-list-input__item dm-list-input__item--visible\\"><div class=\\"dm-list-input__row\\">
           <div class=\\"govuk-form-group dm-list-input__form-group\\">
-    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-2-1\\">
+    <label class=\\"govuk-label dm-list-input__item-label \\" for=\\"my-list-2\\">
       <span class=\\"govuk-visually-hidden\\">What requirements are essential to carry out the work?. Number </span><span class=\\"dm-list-input__counter\\">1</span>.
     </label>
-  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-2-1\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
+  <input class=\\"govuk-input govuk-input dm-list-input__item-input\\" id=\\"my-list-2\\" name=\\"requirements\\" type=\\"text\\" value=\\"Professionally initiate innovative partnerships.\\"></div>
           <button type=\\"button\\" class=\\"govuk-button govuk-button--secondary dm-list-input__item-remove dm-list-input__item-remove--hidden\\" data-module=\\"govuk-button\\">
   Remove <span class=\\"govuk-visually-hidden\\">entry number <span class=\\"dm-list-input__counter\\">1</span></span>
 </button>

--- a/src/digitalmarketplace/components/list-input/list-input.test.js
+++ b/src/digitalmarketplace/components/list-input/list-input.test.js
@@ -114,7 +114,7 @@ describe('/components/list-input', () => {
           await page.click(lastRow + ' .govuk-button')
           await page.waitForSelector(lastRow, { visible: false })
           const focussedInputID = await page.evaluate(() => document.activeElement.getAttribute('id'))
-          const firstRowInputID = 'my-list-1'
+          const firstRowInputID = 'my-list'
 
           expect(focussedInputID).toEqual(firstRowInputID)
         })

--- a/src/digitalmarketplace/components/list-input/template.njk
+++ b/src/digitalmarketplace/components/list-input/template.njk
@@ -58,7 +58,11 @@
   <div class="dm-list-input__item-container" role="region" aria-live="assertive">
     {% for i in range(0, params.maxItems) -%}
       {%- set item = params.items[i] if params.items[i] else {} -%}
-      {%- set entryItemId = params.id ~ '-' ~ loop.index -%}
+      {%- if loop.first -%}
+        {%- set entryItemId = params.id -%}
+      {% else %}
+        {%- set entryItemId = params.id ~ '-' ~ loop.index -%}
+      {%- endif -%}
       {# Classes #}
       {%- set itemClassesBase = 'govuk-input dm-list-input__item-input' -%}
       {%- set itemClassesLarge = ' dm-list-input__item-input--large' if i > 99 else '' -%}

--- a/src/digitalmarketplace/components/list-input/template.test.js
+++ b/src/digitalmarketplace/components/list-input/template.test.js
@@ -42,7 +42,9 @@ describe('List Input', () => {
         const $inputs = $component.find(`input[name="${examples.default.name}"]`)
         expect($inputs.length).toEqual(examples.default.maxItems)
 
-        for (let i = 1; i <= examples.default.maxItems; i++) {
+        expect($inputs[0].attribs.id).toEqual(examples.default.id)
+
+        for (let i = 2; i <= examples.default.maxItems; i++) {
           expect($inputs[i - 1].attribs.id).toEqual(examples.default.id + '-' + i)
         }
       })


### PR DESCRIPTION
We want to be consistent with radios and checkboxes in govuk-frontend
v3, which also don't have a suffix for the first input [1].

[1]: https://github.com/alphagov/govuk-frontend/commit/e25b0e100298ca3ed758bfda3f312448d84ca229