### PR TITLE
use lts codename for nvm version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-10.23.0
+lts/dubnium


### PR DESCRIPTION
We can save a bit of maintenance by pointing NVM to the LTS release to save having to keep updating for minor versions. This is consistent with the approach taken by PaaS team in 
https://github.com/alphagov/paas-admin/blob/bab335a9f7058b478a44565e424ed3c6074ef2d1/.nvmrc#L1