### PR TITLE
Release 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See below for Changelog examples.
 
+🔧 Fixes:
+
+  - The header component now has the correct path for the fallback crown logo image [PR #283](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/283)
+
 ## 2.9.0
 
 🆕 New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 See below for Changelog examples.
 
+## 2.9.1
+
 🔧 Fixes:
 
   - The header component now has the correct path for the fallback crown logo image [PR #283](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/283)

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
🔧 Fixes:

  - The header component now has the correct path for the fallback crown logo image [PR #283](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/283)