### PR TITLE
Run pre-merge checks on Node 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Spotted this while looking at some Dependabot PRs.
We want to upgrade off Node 10 as soon as possible, ideally to Node 14.x which is the most recent LTS version. Add it to our pre-merge checks so we can see if we get any errors.