### PR TITLE
Fix publish package workflow

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -18,5 +18,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm publish
+      working-directory: ./package
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
npm was failing to publish our packages for this repo because we were running `npm publish` in the repo directory rather than the package directory `./package`. This commit adds the correct working directory to the workflow step.