### PR TITLE
Release 2.9.2

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -6,18 +6,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Read .nvmrc
-      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-      id: nvm
-
     - uses: actions/checkout@v2
     # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v2
       with:
-        node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        # TODO: Can we derive this from .nvmrc
+        node-version: '14'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm publish
       working-directory: ./package
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -18,5 +18,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm publish
+      working-directory: ./package
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -14,6 +14,7 @@ jobs:
         node-version: '14'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
+    - run: npm run build
     - run: npm publish
       working-directory: ./package
       env:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/fermium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.9.2
+
+🔧 Fixes:
+
+  - The Node.js Package workflow now publishes to npm correctly (backports PRs [#303](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/303), [#307](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/307), [#308](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/308))
+
 ## 2.9.1
 
 🔧 Fixes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
🔧 Fixes:

 - The Node.js Package workflow now publishes to npm correctly (backports PRs [#303](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/303), [#307](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/307), [#308](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/308))