### PR TITLE
Add dist-tag govuk-frontend-2 to npm releases from this branch

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -15,7 +15,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm run build
-    - run: npm publish
+    - run: npm publish --tag govuk-frontend-2
       working-directory: ./package
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 


### PR DESCRIPTION
We want to make sure releases to the 2.x.x series are not treated as the latest version by npm. We add a [dist-tag] to npm publish to do this; by supplying a tag to `npm publish` the default tag `latest` will not be applied.

We can make the change in this workflow file because when a GitHub Release is made from a commit, GitHub Actions will use the workflow file in that commit, so the main branch shouldn't have the `--tag` argument.

[dist-tag]: https://docs.npmjs.com/adding-dist-tags-to-packages